### PR TITLE
Add json_object response format to OpenAI calls

### DIFF
--- a/src/lib/openai/optimizedBatchClassification.ts
+++ b/src/lib/openai/optimizedBatchClassification.ts
@@ -161,9 +161,13 @@ function validateApiResponse(content: string, expectedCount: number): any[] {
   }
 
   console.log(`[VALIDATION] Raw API response:`, content);
-  
-  // Clean the response - remove markdown formatting
-  const cleanContent = content.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim();
+
+  // The `json_object` response format should already be valid JSON.
+  // Remove possible markdown fences for backward compatibility.
+  const cleanContent = content
+    .replace(/```json\n?/g, '')
+    .replace(/```\n?/g, '')
+    .trim();
   
   let parsed: any;
   try {
@@ -300,18 +304,19 @@ export async function optimizedBatchClassification(
 Names to classify:
 ${batchNames.map((name, idx) => `${idx + 1}. "${name}"`).join('\n')}`;
 
-          const apiCall = openaiClient.chat.completions.create({
-            model: CLASSIFICATION_MODEL,
-            messages: [
-              {
-                role: "system",
-                content: "You are an expert classifier. Return only valid JSON array, no other text."
-              },
-              {
-                role: "user",
-                content: prompt
-              }
-            ],
+            const apiCall = openaiClient.chat.completions.create({
+              model: CLASSIFICATION_MODEL,
+              messages: [
+                {
+                  role: "system",
+                  content: "You are an expert classifier. Return only valid JSON array, no other text."
+                },
+                {
+                  role: "user",
+                  content: prompt
+                }
+              ],
+            response_format: { type: "json_object" },
             temperature: 0.1,
             max_tokens: 800
           });

--- a/src/lib/openai/trueBatchAPI.ts
+++ b/src/lib/openai/trueBatchAPI.ts
@@ -88,6 +88,7 @@ export async function createBatchJob(
             content: `Classify this payee name: "${name}"\n\nReturn ONLY a JSON object like: {"classification": "Business", "confidence": 95, "reasoning": "Contains LLC suffix indicating business entity"}`
           }
         ],
+        response_format: { type: 'json_object' },
         temperature: 0.1,
         max_tokens: 200
       }


### PR DESCRIPTION
## Summary
- update `optimizedBatchClassification` to request `json_object` responses
- clarify API response cleaning in `validateApiResponse`
- ensure batch jobs use `json_object` format in `trueBatchAPI`

## Testing
- `npm run lint` *(fails: Unexpected any, forbidden require imports)*

------
https://chatgpt.com/codex/tasks/task_e_684234dff9d88321a5a90997c9339cda