### PR TITLE
Add keyword exclusion test and convert ruleBased test to vitest

### DIFF
--- a/tests/keywordExclusion.test.ts
+++ b/tests/keywordExclusion.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { checkKeywordExclusion } from '@/lib/classification/enhancedKeywordExclusion';
+
+function mockLocalStorage(keywords: string[]) {
+  const storage = {
+    getItem: vi.fn(() => JSON.stringify(keywords)),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn()
+  } as unknown as Storage;
+  Object.defineProperty(global, 'localStorage', { value: storage, configurable: true });
+}
+
+describe('checkKeywordExclusion', () => {
+  afterEach(() => {
+    // cleanup mocked localStorage
+    // @ts-ignore
+    delete (global as any).localStorage;
+  });
+
+  it('marks name as excluded when keyword present', () => {
+    mockLocalStorage(['Example']);
+    const result = checkKeywordExclusion('Example Company');
+    expect(result.isExcluded).toBe(true);
+  });
+
+  it('does not exclude when keyword missing', () => {
+    mockLocalStorage(['Test']);
+    const result = checkKeywordExclusion('Example Company');
+    expect(result.isExcluded).toBe(false);
+  });
+});

--- a/tests/ruleBasedClassification.test.ts
+++ b/tests/ruleBasedClassification.test.ts
@@ -1,27 +1,28 @@
-import test from 'node:test';
-import assert from 'node:assert/strict';
+import { describe, it, expect } from 'vitest';
 import { applyRuleBasedClassification } from '../src/lib/classification/ruleBasedClassification.ts';
 
-test('detects business by Spanish legal suffix', () => {
-  const result = applyRuleBasedClassification('Compania de Software S.L.');
-  assert.ok(result, 'classification result should not be null');
-  assert.equal(result!.classification, 'Business');
-});
+describe('applyRuleBasedClassification', () => {
+  it('detects business by Spanish legal suffix', () => {
+    const result = applyRuleBasedClassification('Compania de Software S.L.');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Business');
+  });
 
-test('detects business by French legal suffix', () => {
-  const result = applyRuleBasedClassification('Entreprise Exemple SARL');
-  assert.ok(result, 'classification result should not be null');
-  assert.equal(result!.classification, 'Business');
-});
+  it('detects business by French legal suffix', () => {
+    const result = applyRuleBasedClassification('Entreprise Exemple SARL');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Business');
+  });
 
-test('detects business by non-English keyword', () => {
-  const result = applyRuleBasedClassification('Rodriguez Soluciones');
-  assert.ok(result, 'classification result should not be null');
-  assert.equal(result!.classification, 'Business');
-});
+  it('detects business by non-English keyword', () => {
+    const result = applyRuleBasedClassification('Rodriguez Soluciones');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Business');
+  });
 
-test('detects individual name', () => {
-  const result = applyRuleBasedClassification('Juan Perez');
-  assert.ok(result, 'classification result should not be null');
-  assert.equal(result!.classification, 'Individual');
+  it('detects individual name', () => {
+    const result = applyRuleBasedClassification('Juan Perez');
+    expect(result).not.toBeNull();
+    expect(result!.classification).toBe('Individual');
+  });
 });


### PR DESCRIPTION
## Summary
- add a new test for `checkKeywordExclusion`
- convert existing rule-based tests to use vitest

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684237b52c5083218347d3768fc11478