### PR TITLE
Add localStorage persistence for exclusion keywords

### DIFF
--- a/src/lib/classification/enhancedKeywordExclusion.ts
+++ b/src/lib/classification/enhancedKeywordExclusion.ts
@@ -2,10 +2,15 @@
 import { KeywordExclusionResult, SimilarityScores } from '../types';
 import { calculateCombinedSimilarity, advancedNormalization } from './stringMatching';
 
+/**
+ * Key used to store exclusion keywords in localStorage
+ */
+export const EXCLUDED_KEYWORDS_STORAGE_KEY = 'excludedKeywords';
+
 // Load exclusion keywords from localStorage
 function getExclusionKeywords(): string[] {
   try {
-    const stored = localStorage.getItem('excludedKeywords');
+    const stored = localStorage.getItem(EXCLUDED_KEYWORDS_STORAGE_KEY);
     return stored ? JSON.parse(stored) : [];
   } catch (error) {
     console.warn('Failed to load exclusion keywords:', error);


### PR DESCRIPTION
## Summary
- persist keyword exclusions across sessions
- export a shared localStorage key constant

## Testing
- `npm run lint`
- `npm test` *(fails: No test suite found)*

------
https://chatgpt.com/codex/tasks/task_e_684237b485b0832193fccfe94d8218f5