### PR TITLE
Add configurable API timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,9 @@ Additional constants in `config.ts` include `MAX_CONCURRENCY` for controlling
 the number of concurrent classification requests and `MAX_BATCH_SIZE` for
 limiting batch size. The OpenAI client settings in `openai/config.ts` expose
 `DEFAULT_API_TIMEOUT` (20&nbsp;seconds by default) which defines how long the
-system waits for each API response.
+system waits for each API response. You can override this timeout by setting the
+`OPENAI_TIMEOUT_MS` environment variable or by passing a `timeout` parameter to
+the classification functions.
 
 Increasing `aiThreshold` means rule‑based and NLP results must be more confident
 before the AI model is called. A higher threshold typically improves accuracy at

--- a/src/lib/openai/config.ts
+++ b/src/lib/openai/config.ts
@@ -1,6 +1,8 @@
 
 // Optimized timeout for better reliability and speed
-export const DEFAULT_API_TIMEOUT = 20000; // Increased to 20 seconds for batch processing
+const envTimeout = parseInt(process.env.OPENAI_TIMEOUT_MS || '', 10);
+export const DEFAULT_API_TIMEOUT =
+  Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : 20000; // Increased to 20 seconds for batch processing
 
 // Optimized batch size for faster processing
 export const MAX_BATCH_SIZE = 15; // Increased for better throughput


### PR DESCRIPTION
## Summary
- make API timeout configurable via `OPENAI_TIMEOUT_MS`
- document the new option in the Classification section of the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423970ab488321b89bf8baddef7793