### PR TITLE
Add configurable batch/concurrency limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,15 @@ system waits for each API response. You can override this timeout by setting the
 `OPENAI_TIMEOUT_MS` environment variable or by passing a `timeout` parameter to
 the classification functions.
 
+The library also respects several optional environment variables:
+
+- `CLASSIFIER_MAX_CONCURRENCY` – maximum number of concurrent classification tasks.
+- `CLASSIFIER_MAX_BATCH_SIZE` – limit on batch size for classifier utilities.
+- `OPENAI_MAX_BATCH_SIZE` – batch size for OpenAI requests.
+- `OPENAI_MAX_PARALLEL_BATCHES` – maximum OpenAI batches processed concurrently.
+
+Each variable falls back to a sensible default when not provided.
+
 Increasing `aiThreshold` means rule‑based and NLP results must be more confident
 before the AI model is called. A higher threshold typically improves accuracy at
 the cost of additional API usage and slower processing. Likewise, extending

--- a/src/lib/classification/config.ts
+++ b/src/lib/classification/config.ts
@@ -12,10 +12,14 @@ export const DEFAULT_CLASSIFICATION_CONFIG: ClassificationConfig = {
 };
 
 // Increased concurrency limits for better parallel processing
-export const MAX_CONCURRENCY = 20; // Doubled from 10
+const envConcurrency = parseInt(process.env.CLASSIFIER_MAX_CONCURRENCY || '', 10);
+export const MAX_CONCURRENCY =
+  Number.isFinite(envConcurrency) && envConcurrency > 0 ? envConcurrency : 20; // Doubled from 10
 
 // Maximum batch size for AI classification
-export const MAX_BATCH_SIZE = 15; // Increased from 5
+const envBatchSize = parseInt(process.env.CLASSIFIER_MAX_BATCH_SIZE || '', 10);
+export const MAX_BATCH_SIZE =
+  Number.isFinite(envBatchSize) && envBatchSize > 0 ? envBatchSize : 15; // Increased from 5
 
 // Extended name similarity threshold (Levenshtein distance %)
 export const NAME_SIMILARITY_THRESHOLD = 85; // 85% similar names treated as same

--- a/src/lib/openai/config.ts
+++ b/src/lib/openai/config.ts
@@ -5,15 +5,19 @@ export const DEFAULT_API_TIMEOUT =
   Number.isFinite(envTimeout) && envTimeout > 0 ? envTimeout : 20000; // Increased to 20 seconds for batch processing
 
 // Optimized batch size for faster processing
-export const MAX_BATCH_SIZE = 15; // Increased for better throughput
+const envBatchSize = parseInt(process.env.OPENAI_MAX_BATCH_SIZE || '', 10);
+export const MAX_BATCH_SIZE =
+  Number.isFinite(envBatchSize) && envBatchSize > 0 ? envBatchSize : 15; // Increased for better throughput
 
 // Use the most reliable and fast model
 export const CLASSIFICATION_MODEL = 'gpt-4o-mini';
 
 // Enhanced processing configuration
+const envParallel = parseInt(process.env.OPENAI_MAX_PARALLEL_BATCHES || '', 10);
 export const ENHANCED_PROCESSING = {
-  BATCH_SIZE: 15,
-  MAX_PARALLEL_BATCHES: 3,
+  BATCH_SIZE: MAX_BATCH_SIZE,
+  MAX_PARALLEL_BATCHES:
+    Number.isFinite(envParallel) && envParallel > 0 ? envParallel : 3,
   CACHE_TTL: 30 * 60 * 1000, // 30 minutes
   MAX_RETRIES: 3,
   RETRY_DELAY_BASE: 1000

--- a/tests/configEnvOverrides.test.ts
+++ b/tests/configEnvOverrides.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const originalEnv = process.env;
+
+describe('environment configuration overrides', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses CLASSIFIER_* env vars', async () => {
+    process.env.CLASSIFIER_MAX_CONCURRENCY = '7';
+    process.env.CLASSIFIER_MAX_BATCH_SIZE = '9';
+    const mod = await import('@/lib/classification/config');
+    expect(mod.MAX_CONCURRENCY).toBe(7);
+    expect(mod.MAX_BATCH_SIZE).toBe(9);
+  });
+
+  it('uses OPENAI_* env vars', async () => {
+    process.env.OPENAI_MAX_BATCH_SIZE = '8';
+    process.env.OPENAI_MAX_PARALLEL_BATCHES = '4';
+    const mod = await import('@/lib/openai/config');
+    expect(mod.MAX_BATCH_SIZE).toBe(8);
+    expect(mod.ENHANCED_PROCESSING.MAX_PARALLEL_BATCHES).toBe(4);
+    expect(mod.MAX_PARALLEL_BATCHES).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary
- respect `CLASSIFIER_MAX_CONCURRENCY` and `CLASSIFIER_MAX_BATCH_SIZE`
- allow `OPENAI_MAX_BATCH_SIZE` and `OPENAI_MAX_PARALLEL_BATCHES`
- document environment variables
- test that environment overrides work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684251d624388321bc669392193bfaec