### PR TITLE
Make rule based classification tests async

### DIFF
--- a/tests/ruleBasedClassification.test.ts
+++ b/tests/ruleBasedClassification.test.ts
@@ -2,26 +2,26 @@ import { describe, it, expect } from 'vitest';
 import { applyRuleBasedClassification } from '../src/lib/classification/ruleBasedClassification.ts';
 
 describe('applyRuleBasedClassification', () => {
-  it('detects business by Spanish legal suffix', () => {
-    const result = applyRuleBasedClassification('Compania de Software S.L.');
+  it('detects business by Spanish legal suffix', async () => {
+    const result = await applyRuleBasedClassification('Compania de Software S.L.');
     expect(result).not.toBeNull();
     expect(result!.classification).toBe('Business');
   });
 
-  it('detects business by French legal suffix', () => {
-    const result = applyRuleBasedClassification('Entreprise Exemple SARL');
+  it('detects business by French legal suffix', async () => {
+    const result = await applyRuleBasedClassification('Entreprise Exemple SARL');
     expect(result).not.toBeNull();
     expect(result!.classification).toBe('Business');
   });
 
-  it('detects business by non-English keyword', () => {
-    const result = applyRuleBasedClassification('Rodriguez Soluciones');
+  it('detects business by non-English keyword', async () => {
+    const result = await applyRuleBasedClassification('Rodriguez Soluciones');
     expect(result).not.toBeNull();
     expect(result!.classification).toBe('Business');
   });
 
-  it('detects individual name', () => {
-    const result = applyRuleBasedClassification('Juan Perez');
+  it('detects individual name', async () => {
+    const result = await applyRuleBasedClassification('Juan Perez');
     expect(result).not.toBeNull();
     expect(result!.classification).toBe('Individual');
   });


### PR DESCRIPTION
## Summary
- update rule-based classification tests to be async

## Testing
- `npm install`
- `npm test` *(fails: tests/trueBatchAPI.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_684344ec21cc83219fe417788d610f7c