### PR TITLE
Fix payee_count expectation

### DIFF
--- a/tests/trueBatchAPI.test.ts
+++ b/tests/trueBatchAPI.test.ts
@@ -44,7 +44,8 @@ describe('createBatchJob', () => {
       metadata: { payee_count: '2', description: 'desc' }
     });
     expect(job.id).toBe('batch1');
-    expect(job.metadata?.payee_count).toBe(2);
+    // payee_count is stored as a string in the returned metadata
+    expect(job.metadata?.payee_count).toBe('2');
   });
 });
 


### PR DESCRIPTION
## Summary
- keep `payee_count` metadata as a string
- update test to expect string value when verifying returned batch job

## Testing
- `npm test` *(fails: applyRuleBasedClassification test assertions; getBatchJobResults error)*

------
https://chatgpt.com/codex/tasks/task_e_684344ed32d4832192cf7f0bdc302f4f