### PR TITLE
Fix batch job status check in trueBatchAPI

### DIFF
--- a/src/lib/openai/trueBatchAPI.ts
+++ b/src/lib/openai/trueBatchAPI.ts
@@ -164,12 +164,22 @@ export async function createBatchJob(
   } as BatchJob;
 }
 
+/**
+ * Download and parse the results for a completed batch job.
+ *
+ * Throws "Batch job is not completed" if the job has not finished, or
+ * "Batch job has no output file" if the output file id is missing.
+ */
 export async function getBatchJobResults(
   job: BatchJob,
   payeeNames: string[]
 ): Promise<ProcessedBatchResult[]> {
   logger.info(`[BATCH API] Getting results for job: ${job.id}`);
-  
+
+  if (job.status !== 'completed') {
+    throw new Error('Batch job is not completed');
+  }
+
   if (!job.output_file_id) {
     throw new Error('Batch job has no output file');
   }


### PR DESCRIPTION
## Summary
- enforce that `getBatchJobResults` throws `"Batch job is not completed"` when the job hasn't finished
- document both possible error cases in `getBatchJobResults`

## Testing
- `npm test` *(fails: expected classification results in other tests)*

------
https://chatgpt.com/codex/tasks/task_e_684344eee3308321b1f8f1bc17ff17b9