### PR TITLE
Implement includeAllColumns in export

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,13 @@ classifier will load it at runtime.
 
 API keys are stored using AES‑GCM encryption in `localStorage`, with the
 encryption key kept in `sessionStorage` for added security.
+
+## Exporting classification results
+
+Use `exportResultsWithOriginalDataV3` to combine processed results with the
+original uploaded rows. The function accepts an optional `includeAllColumns`
+boolean parameter.
+
+- When `true` (default), the exported rows contain every original field along
+  with additional AI columns.
+- When `false`, only the AI-related columns are included.

--- a/src/lib/classification/exporters/mainExporter.ts
+++ b/src/lib/classification/exporters/mainExporter.ts
@@ -5,6 +5,9 @@ import { createFallbackExportData } from './fallbackExporter';
 
 /**
  * Main export function with perfect 1:1 correspondence
+ *
+ * @param batchResult - Results plus original rows
+ * @param includeAllColumns - If false, exclude original row fields and output only AI columns
  */
 export function exportResultsWithOriginalDataV3(
   batchResult: any,
@@ -29,6 +32,6 @@ export function exportResultsWithOriginalDataV3(
   return batchResult.originalFileData.map((originalRow: any, index: number) => {
     // Get the corresponding result by exact index match
     const result = resultsMap.get(index);
-    return mergeRowWithResult(originalRow, result, index);
+    return mergeRowWithResult(originalRow, result, index, includeAllColumns);
   });
 }

--- a/src/lib/classification/exporters/resultsMerger.ts
+++ b/src/lib/classification/exporters/resultsMerger.ts
@@ -16,9 +16,14 @@ export function createResultsMap(results: any[]): Map<number, any> {
 /**
  * Merges original row data with AI classification results
  */
-export function mergeRowWithResult(originalRow: any, result: any | undefined, index: number): ExportRow {
-  // Start with ALL original data
-  const exportRow: ExportRow = { ...originalRow };
+export function mergeRowWithResult(
+  originalRow: any,
+  result: any | undefined,
+  index: number,
+  includeAllColumns: boolean = true
+): ExportRow {
+  // Start with ALL original data when requested, otherwise begin with an empty object
+  const exportRow: ExportRow = includeAllColumns ? { ...originalRow } : {};
 
   if (!result) {
     console.error(`[MERGE] CRITICAL: No result found for row ${index} - this should NEVER happen with 1:1 correspondence`);

--- a/tests/exporterIncludeColumns.test.ts
+++ b/tests/exporterIncludeColumns.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { exportResultsWithOriginalDataV3 } from '@/lib/classification/exporters';
+
+const baseResult = {
+  payeeName: 'Acme LLC',
+  result: {
+    classification: 'Business',
+    confidence: 95,
+    reasoning: 'ok',
+    processingTier: 'AI-Powered'
+  },
+  timestamp: new Date('2024-01-01T00:00:00Z'),
+  rowIndex: 0
+};
+
+describe('exportResultsWithOriginalDataV3 includeAllColumns option', () => {
+  const batch = {
+    results: [baseResult],
+    successCount: 1,
+    failureCount: 0,
+    originalFileData: [{ Name: 'Acme LLC', Extra: 'x' }]
+  };
+
+  it('returns only AI columns when includeAllColumns is false', () => {
+    const rows = exportResultsWithOriginalDataV3(batch, false);
+    const row = rows[0];
+    expect(row.Name).toBeUndefined();
+    expect(row['AI_Classification']).toBe('Business');
+  });
+
+  it('preserves original columns when includeAllColumns is true', () => {
+    const rows = exportResultsWithOriginalDataV3(batch, true);
+    const row = rows[0];
+    expect(row.Name).toBe('Acme LLC');
+    expect(row['AI_Classification']).toBe('Business');
+  });
+});


### PR DESCRIPTION
## Summary
- make results exporter respect the `includeAllColumns` flag
- document exporter option in README
- add test for new export behaviour

## Testing
- `npx -y vitest run` *(fails: Cannot find package 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_68436ec741548321baafa72168ce942a