### PR TITLE
Track payee column in batch processing

### DIFF
--- a/src/components/BatchClassificationForm.tsx
+++ b/src/components/BatchClassificationForm.tsx
@@ -19,11 +19,17 @@ const BatchClassificationForm = ({ onComplete }: BatchClassificationFormProps) =
   const [batchJobs, setBatchJobs] = useState<BatchJob[]>([]);
   const [payeeNamesMap, setPayeeNamesMap] = useState<Record<string, string[]>>({});
   const [originalFileDataMap, setOriginalFileDataMap] = useState<Record<string, any[]>>({});
+  const [payeeColumnMap, setPayeeColumnMap] = useState<Record<string, string>>({});
   const [batchResults, setBatchResults] = useState<PayeeClassification[]>([]);
   const [processingSummary, setProcessingSummary] = useState<BatchProcessingResult | null>(null);
   const { toast } = useToast();
 
-  const handleBatchJobCreated = (batchJob: BatchJob, payeeNames: string[], originalFileData: any[]) => {
+  const handleBatchJobCreated = (
+    batchJob: BatchJob,
+    payeeNames: string[],
+    originalFileData: any[],
+    payeeColumnName: string
+  ) => {
     console.log(`[BATCH FORM] Batch job created with ${payeeNames.length} payees and ${originalFileData.length} original data rows`);
     console.log(`[BATCH FORM] Original data sample:`, originalFileData.slice(0, 2));
     
@@ -32,11 +38,17 @@ const BatchClassificationForm = ({ onComplete }: BatchClassificationFormProps) =
       ...prev,
       [batchJob.id]: payeeNames
     }));
-    
+
     // Store original file data for this job - CRITICAL for export
     setOriginalFileDataMap(prev => ({
       ...prev,
       [batchJob.id]: originalFileData
+    }));
+
+    // Store the payee column name
+    setPayeeColumnMap(prev => ({
+      ...prev,
+      [batchJob.id]: payeeColumnName
     }));
     
     console.log(`[BATCH FORM] Stored original file data for job ${batchJob.id}:`, {
@@ -77,6 +89,10 @@ const BatchClassificationForm = ({ onComplete }: BatchClassificationFormProps) =
       const { [jobId]: removed, ...rest } = prev;
       return rest;
     });
+    setPayeeColumnMap(prev => {
+      const { [jobId]: removed, ...rest } = prev;
+      return rest;
+    });
   };
 
   const handleReset = () => {
@@ -110,6 +126,7 @@ const BatchClassificationForm = ({ onComplete }: BatchClassificationFormProps) =
           jobs={batchJobs}
           payeeNamesMap={payeeNamesMap}
           originalFileDataMap={originalFileDataMap}
+          payeeColumnNameMap={payeeColumnMap}
           onJobUpdate={handleJobUpdate}
           onJobComplete={handleJobComplete}
           onJobDelete={handleJobDelete}

--- a/src/components/BatchJobManager.tsx
+++ b/src/components/BatchJobManager.tsx
@@ -15,18 +15,20 @@ interface BatchJobManagerProps {
   jobs: BatchJob[];
   payeeNamesMap: Record<string, string[]>;
   originalFileDataMap: Record<string, any[]>;
+  payeeColumnNameMap: Record<string, string>;
   onJobUpdate: (job: BatchJob) => void;
   onJobComplete: (results: PayeeClassification[], summary: BatchProcessingResult, jobId: string) => void;
   onJobDelete: (jobId: string) => void;
 }
 
-const BatchJobManager = ({ 
-  jobs, 
-  payeeNamesMap, 
+const BatchJobManager = ({
+  jobs,
+  payeeNamesMap,
   originalFileDataMap,
-  onJobUpdate, 
-  onJobComplete, 
-  onJobDelete 
+  payeeColumnNameMap,
+  onJobUpdate,
+  onJobComplete,
+  onJobDelete
 }: BatchJobManagerProps) => {
   const [refreshingJobs, setRefreshingJobs] = useState<Set<string>>(new Set());
   const [downloadingJobs, setDownloadingJobs] = useState<Set<string>>(new Set());
@@ -77,6 +79,7 @@ const BatchJobManager = ({
       console.log(`[BATCH MANAGER] Downloading results for job ${job.id} with GUARANTEED alignment`);
       const payeeNames = payeeNamesMap[job.id] || [];
       const originalFileData = originalFileDataMap[job.id] || [];
+      const payeeColumnName = payeeColumnNameMap[job.id];
       
       console.log(`[BATCH MANAGER] Data verification:`, {
         payeeNamesLength: payeeNames.length,
@@ -163,7 +166,8 @@ const BatchJobManager = ({
         results: classifications,
         successCount,
         failureCount,
-        originalFileData
+        originalFileData,
+        payeeColumnName
       };
 
       onJobComplete(classifications, summary, job.id);

--- a/src/components/FileUploadForm.tsx
+++ b/src/components/FileUploadForm.tsx
@@ -10,7 +10,12 @@ import FileUploadActions from "./file-upload/FileUploadActions";
 import { BatchJob } from "@/lib/openai/trueBatchAPI";
 
 interface FileUploadFormProps {
-  onBatchJobCreated: (batchJob: BatchJob, payeeNames: string[], originalFileData: any[]) => void;
+  onBatchJobCreated: (
+    batchJob: BatchJob,
+    payeeNames: string[],
+    originalFileData: any[],
+    payeeColumnName: string
+  ) => void;
 }
 
 const FileUploadForm = ({ onBatchJobCreated }: FileUploadFormProps) => {
@@ -113,7 +118,8 @@ const FileUploadForm = ({ onBatchJobCreated }: FileUploadFormProps) => {
       await onBatchJobCreated(
         mockBatchJob,
         validationResult.payeeNames,
-        validationResult.originalData || []
+        validationResult.originalData || [],
+        selectedColumn
       );
     } catch (error) {
       console.error('Submit error:', error);

--- a/src/lib/classification/batchExporter.ts
+++ b/src/lib/classification/batchExporter.ts
@@ -123,12 +123,12 @@ export function exportResultsWithOriginalDataV3(
 
   // Validate data alignment first
   const firstOriginalRow = batchResult.originalFileData[0];
-  const payeeColumnName = firstOriginalRow ? Object.keys(firstOriginalRow).find(key =>
+  const payeeColumnName = batchResult.payeeColumnName || (firstOriginalRow ? Object.keys(firstOriginalRow).find(key =>
     key.toLowerCase().includes('payee') ||
     key.toLowerCase().includes('name') ||
     key.toLowerCase().includes('supplier') ||
     key.toLowerCase().includes('vendor')
-  ) : undefined;
+  ) : undefined);
 
   const validation = validateDataAlignment(
     batchResult.originalFileData,

--- a/src/lib/classification/enhancedBatchProcessorV2.ts
+++ b/src/lib/classification/enhancedBatchProcessorV2.ts
@@ -17,7 +17,8 @@ export interface BatchRow {
 export async function enhancedProcessBatchV2(
   rows: BatchRow[],
   config: ClassificationConfig = DEFAULT_CLASSIFICATION_CONFIG,
-  onProgress?: (processed: number, total: number, current: string) => void
+  onProgress?: (processed: number, total: number, current: string) => void,
+  payeeColumnName?: string
 ): Promise<BatchProcessingResult> {
   const startTime = Date.now();
   const results: PayeeClassification[] = [];
@@ -200,6 +201,7 @@ export async function enhancedProcessBatchV2(
     results,
     successCount: results.filter(r => r.result.processingTier !== 'Failed').length,
     failureCount: results.filter(r => r.result.processingTier === 'Failed').length,
+    payeeColumnName,
     processingTime,
     originalFileData: rows.map(row => row.originalData),
     enhancedStats

--- a/src/lib/classification/enhancedBatchProcessorV3.ts
+++ b/src/lib/classification/enhancedBatchProcessorV3.ts
@@ -13,7 +13,8 @@ import { exportResultsWithOriginalDataV3 } from './batchExporter';
 export async function enhancedProcessBatchV3(
   payeeNames: string[],
   config: ClassificationConfig = DEFAULT_CLASSIFICATION_CONFIG,
-  originalFileData?: any[]
+  originalFileData?: any[],
+  payeeColumnName?: string
 ): Promise<BatchProcessingResult> {
   const startTime = Date.now();
   
@@ -103,6 +104,7 @@ export async function enhancedProcessBatchV3(
     failureCount: 0, // NO FAILURES!
     processingTime,
     originalFileData,
+    payeeColumnName,
     enhancedStats
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -38,6 +38,7 @@ export interface BatchProcessingResult {
   results: PayeeClassification[];
   successCount: number;
   failureCount: number;
+  payeeColumnName?: string;
   processingTime?: number;
   originalFileData?: any[]; // Preserve original file structure
   enhancedStats?: EnhancedBatchStatistics;

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -41,7 +41,8 @@ export const downloadCSV = (results: PayeeClassification[]) => {
     results,
     successCount: results.filter(r => r.result.processingTier !== 'Failed').length,
     failureCount: results.filter(r => r.result.processingTier === 'Failed').length,
-    originalFileData: results.map(r => r.originalData)
+    originalFileData: results.map(r => r.originalData),
+    payeeColumnName: undefined
   };
 
   const exportRows = exportResultsWithOriginalDataV3(summary, true);


### PR DESCRIPTION
## Summary
- track the column used for payee names in `BatchProcessingResult`
- pass the selected column from `FileUploadForm` through `BatchClassificationForm` and `BatchJobManager`
- include `payeeColumnName` when creating batch summaries
- use the provided column name when exporting results
- expose payee column in batch processor return types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843727af36883219f6d36b643571dca