### PR TITLE
Add payee column alignment test

### DIFF
--- a/tests/exportAlignment.test.ts
+++ b/tests/exportAlignment.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { exportResultsWithOriginalDataV3 } from '@/lib/classification/batchExporter';
+import type { BatchProcessingResult } from '@/lib/types';
+
+// Helper to create a basic classification result
+const createResult = (payeeName: string, classification: 'Business' | 'Individual'): any => ({
+  payeeName,
+  result: {
+    classification,
+    confidence: 90,
+    reasoning: 'r',
+    processingTier: 'AI-Powered'
+  },
+  timestamp: new Date('2024-01-01T00:00:00Z'),
+  rowIndex: -1 // force name based matching
+});
+
+describe('exportResultsWithOriginalDataV3 payee column matching', () => {
+  it('uses the specified payee column when matching results', () => {
+    const batch: BatchProcessingResult = {
+      results: [
+        createResult('Acme LLC', 'Business'),
+        createResult('John Doe', 'Individual')
+      ],
+      successCount: 2,
+      failureCount: 0,
+      originalFileData: [
+        { 'Vendor Name': 'Acme LLC', 'Contact Name': 'Someone' },
+        { 'Vendor Name': 'John Doe', 'Contact Name': 'Other' }
+      ]
+    };
+
+    const rows = exportResultsWithOriginalDataV3(batch, true);
+
+    expect(rows[0]['Vendor Name']).toBe('Acme LLC');
+    expect(rows[0]['AI_Classification']).toBe('Business');
+    expect(rows[1]['Vendor Name']).toBe('John Doe');
+    expect(rows[1]['AI_Classification']).toBe('Individual');
+  });
+});


### PR DESCRIPTION
## Summary
- add a new vitest checking that the batch exporter falls back to the `Vendor Name` column

## Testing
- `npm install`
- `npx vitest run`

------
https://chatgpt.com/codex/tasks/task_e_6843727c81ac8321abe3d701cff2d3e2