### PR TITLE
Improve findResultByName normalization

### DIFF
--- a/src/lib/classification/batchExporter.ts
+++ b/src/lib/classification/batchExporter.ts
@@ -1,4 +1,5 @@
 import { BatchProcessingResult } from '../types';
+import { normalizePayeeName } from './nameProcessing';
 
 /**
  * Validate that payee names match between results and original data
@@ -50,12 +51,14 @@ function validateDataAlignment(
  * Find matching result by payee name (fallback when index matching fails)
  */
 export function findResultByName(payeeName: string, results: any[], preferredIndex?: number): any | null {
-  const normalizedTargetName = payeeName.trim().toLowerCase();
+  const normalizedTargetName = normalizePayeeName(payeeName);
 
   // Gather all exact matches
-  const exactMatches = results.filter(result =>
-    result.payeeName && result.payeeName.trim().toLowerCase() === normalizedTargetName
-  );
+  const exactMatches = results.filter(result => {
+    if (!result.payeeName) return false;
+    const resultNorm = normalizePayeeName(result.payeeName);
+    return resultNorm === normalizedTargetName;
+  });
 
   if (exactMatches.length > 0) {
     if (preferredIndex !== undefined) {
@@ -68,8 +71,8 @@ export function findResultByName(payeeName: string, results: any[], preferredInd
   // Gather fuzzy matches (contains)
   const fuzzyMatches = results.filter(result => {
     if (!result.payeeName) return false;
-    const resultName = result.payeeName.trim().toLowerCase();
-    return resultName.includes(normalizedTargetName) || normalizedTargetName.includes(resultName);
+    const resultNorm = normalizePayeeName(result.payeeName);
+    return resultNorm.includes(normalizedTargetName) || normalizedTargetName.includes(resultNorm);
   });
 
   if (fuzzyMatches.length > 0) {

--- a/tests/batchExporter.test.ts
+++ b/tests/batchExporter.test.ts
@@ -16,4 +16,12 @@ describe('findResultByName', () => {
     const match = findResultByName('Acme', results, 5);
     expect(match?.rowIndex).toBe(0);
   });
+
+  it('matches names ignoring punctuation and spacing differences', () => {
+    const punctuationResults = [
+      { payeeName: 'Pepsi Cola', rowIndex: 0 }
+    ];
+    const match = findResultByName('Pepsi. Cola', punctuationResults);
+    expect(match?.rowIndex).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- improve `findResultByName` to normalize payee names before matching
- test punctuation and spacing differences when matching

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843727bb6348321ac59385465b26f7a