### PR TITLE
Fix openai connection test error

### DIFF
--- a/src/lib/openai/client.ts
+++ b/src/lib/openai/client.ts
@@ -185,9 +185,9 @@ export function clearOpenAIKeys(): void {
  * Test the current OpenAI connection with caching
  */
 export async function testOpenAIConnection(): Promise<boolean> {
+  const now = Date.now();
   try {
     // Use cached result if recent (within 30 seconds)
-    const now = Date.now();
     if (now - lastConnectionTest < 30000 && connectionTestCache) {
       logger.info("[OPENAI_CLIENT] Using cached connection test result");
       return connectionTestCache;


### PR DESCRIPTION
## Summary
- fix variable scope in openai client connection test

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68448ac1502c8321b65da6366112c52d