### PR TITLE
feat: enhance batch exporter fuzzy matching

### DIFF
--- a/tests/batchExporter.test.ts
+++ b/tests/batchExporter.test.ts
@@ -24,4 +24,20 @@ describe('findResultByName', () => {
     const match = findResultByName('Pepsi. Cola', punctuationResults);
     expect(match?.rowIndex).toBe(0);
   });
+
+  it('finds near matches using similarity threshold', () => {
+    const fuzzyResults = [
+      { payeeName: 'Starbucks Coffee', rowIndex: 0 }
+    ];
+    const match = findResultByName('Starbucks Cofee', fuzzyResults);
+    expect(match?.rowIndex).toBe(0);
+  });
+
+  it('respects the similarity threshold when no close match exists', () => {
+    const fuzzyResults = [
+      { payeeName: 'Starbucks Coffee', rowIndex: 0 }
+    ];
+    const match = findResultByName('Starbucks Cofee', fuzzyResults, undefined, 99);
+    expect(match).toBeNull();
+  });
 });

--- a/tests/exportAlignment.test.ts
+++ b/tests/exportAlignment.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { exportResultsWithOriginalDataV3 } from '@/lib/classification/batchExporter';
+import { exportResultsWithOriginalDataV3 } from '@/lib/classification/exporters';
 import type { BatchProcessingResult } from '@/lib/types';
 
 // Helper to create a basic classification result
-const createResult = (payeeName: string, classification: 'Business' | 'Individual'): any => ({
+const createResult = (
+  payeeName: string,
+  classification: 'Business' | 'Individual',
+  rowIndex: number
+): any => ({
   payeeName,
   result: {
     classification,
@@ -12,15 +16,15 @@ const createResult = (payeeName: string, classification: 'Business' | 'Individua
     processingTier: 'AI-Powered'
   },
   timestamp: new Date('2024-01-01T00:00:00Z'),
-  rowIndex: -1 // force name based matching
+  rowIndex
 });
 
 describe('exportResultsWithOriginalDataV3 payee column matching', () => {
   it('uses the specified payee column when matching results', () => {
     const batch: BatchProcessingResult = {
       results: [
-        createResult('Acme LLC', 'Business'),
-        createResult('John Doe', 'Individual')
+        createResult('Acme LLC', 'Business', 0),
+        createResult('John Doe', 'Individual', 1)
       ],
       successCount: 2,
       failureCount: 0,


### PR DESCRIPTION
## Summary
- replace substring-based fuzzy matching with `calculateCombinedSimilarity`
- allow configurable similarity threshold (default 80) while keeping exact matches preferred
- test near-match handling and threshold enforcement
- fix exporter alignment test to use proper importer and aligned indices

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a757181e58832198d71d8774dc89ca