### PR TITLE
refactor: standardize payee normalization

### DIFF
--- a/src/lib/classification/enhancedBatchProcessorV3.ts
+++ b/src/lib/classification/enhancedBatchProcessorV3.ts
@@ -48,9 +48,8 @@ export async function enhancedProcessBatchV3(
           rowIndex: item.originalIndex
         };
         
-        // Cache successful results
-        const normalizedName = item.name.toLowerCase().replace(/[^\w\s]/g, ' ').replace(/\s+/g, ' ').trim();
-        duplicateCache.set(normalizedName, payeeClassification);
+        // Cache successful results using normalized name from deduplication
+        duplicateCache.set(item.normalizedName, payeeClassification);
         
         totalProcessed++;
         if (totalProcessed % 50 === 0) {


### PR DESCRIPTION
## Summary
- use `normalizePayeeName` for deduplication
- cache normalized payee names for reuse
- persist normalized names when caching classification results

## Testing
- `npm test` *(fails: exportResultsWithOriginalDataV3 is not a function)*
- `npm run lint` *(fails: many unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a7571a0c108321b2231f3b6d3c7e29