### PR TITLE
chore: remove unused config parameter from classifyPayee

### DIFF
--- a/src/lib/classification/utils.ts
+++ b/src/lib/classification/utils.ts
@@ -1,5 +1,5 @@
 
-import { ClassificationResult, ClassificationConfig } from '../types';
+import { ClassificationResult } from '../types';
 import { classifyPayeeWithAI } from '../openai/singleClassification';
 import { enhancedClassifyPayeeWithAI } from '../openai/enhancedClassification';
 
@@ -8,7 +8,6 @@ import { enhancedClassifyPayeeWithAI } from '../openai/enhancedClassification';
  */
 export async function classifyPayee(
   payeeName: string,
-  config: ClassificationConfig,
   useEnhanced: boolean = false
 ): Promise<ClassificationResult> {
   console.log(`Classifying "${payeeName}" with real OpenAI API (enhanced: ${useEnhanced})`);


### PR DESCRIPTION
## Summary
- remove unused config from classifyPayee helper

## Testing
- `npm test`
- `npm run lint` *(fails: many `@typescript-eslint/no-explicit-any` and related warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a75a064bfc832191240ebd4eb53b99