### PR TITLE
Normalize payee name comparison for deduplication

### DIFF
--- a/src/lib/classification/keywordExclusion.ts
+++ b/src/lib/classification/keywordExclusion.ts
@@ -664,14 +664,18 @@ export function filterPayeeNames(
 } {
   const validNames: string[] = [];
   const excludedNames: Array<{ name: string; reason: string[] }> = [];
-  const processedNames = new Set<string>(); // Prevent duplicates
+  // Track processed names using a normalized representation to avoid
+  // duplicates that only differ by case or surrounding whitespace
+  const processedNames = new Set<string>();
 
   for (const name of payeeNames) {
-    // Skip if we've already processed this exact name
-    if (processedNames.has(name)) {
+    const normalizedName = name.trim().toUpperCase();
+
+    // Skip if we've already processed this name (case-insensitive)
+    if (processedNames.has(normalizedName)) {
       continue;
     }
-    processedNames.add(name);
+    processedNames.add(normalizedName);
 
     const exclusionResult = checkKeywordExclusion(name, exclusionKeywords);
     

--- a/tests/keywordExclusion.test.ts
+++ b/tests/keywordExclusion.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { checkKeywordExclusion } from '@/lib/classification/enhancedKeywordExclusion';
+import { filterPayeeNames } from '@/lib/classification/keywordExclusion';
 
 function mockLocalStorage(keywords: string[]) {
   const storage = {
@@ -28,5 +29,14 @@ describe('checkKeywordExclusion', () => {
     mockLocalStorage(['Test']);
     const result = checkKeywordExclusion('Example Company');
     expect(result.isExcluded).toBe(false);
+  });
+});
+
+describe('filterPayeeNames', () => {
+  it('deduplicates names irrespective of casing', () => {
+    const result = filterPayeeNames(['Acme', 'acme']);
+
+    expect(result.validNames).toEqual(['Acme']);
+    expect(result.excludedNames).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary
- Normalize payee names when tracking processed entries to remove case/whitespace duplicates
- Add test confirming deduplication of differently-cased payee names

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75a10e3308321a177542c6da5163c