### PR TITLE
Handle invalid inputs in keyword exclusion

### DIFF
--- a/src/lib/classification/keywordExclusion.ts
+++ b/src/lib/classification/keywordExclusion.ts
@@ -613,12 +613,12 @@ export function checkKeywordExclusion(
 ): ExclusionResult {
   console.log(`[KEYWORD EXCLUSION] Testing "${payeeName}" against ${exclusionKeywords.length} keywords`);
   
-  if (!payeeName || typeof payeeName !== 'string') {
+  if (typeof payeeName !== 'string' || !payeeName.trim()) {
     console.log(`[KEYWORD EXCLUSION] Invalid input: "${payeeName}"`);
     return {
-      isExcluded: true,
-      matchedKeywords: ['invalid-input'],
-      originalName: payeeName
+      isExcluded: false,
+      matchedKeywords: [],
+      originalName: String(payeeName)
     };
   }
 
@@ -666,7 +666,11 @@ export function filterPayeeNames(
   const excludedNames: Array<{ name: string; reason: string[] }> = [];
   const processedNames = new Set<string>(); // Prevent duplicates
 
-  for (const name of payeeNames) {
+  for (const rawName of payeeNames) {
+    const name = typeof rawName === 'string' ? rawName.trim() : '';
+    if (!name) {
+      continue; // skip invalid names
+    }
     // Skip if we've already processed this exact name
     if (processedNames.has(name)) {
       continue;
@@ -674,7 +678,7 @@ export function filterPayeeNames(
     processedNames.add(name);
 
     const exclusionResult = checkKeywordExclusion(name, exclusionKeywords);
-    
+
     if (exclusionResult.isExcluded) {
       excludedNames.push({
         name: name,

--- a/tests/hybridBatchProcessor.test.ts
+++ b/tests/hybridBatchProcessor.test.ts
@@ -57,6 +57,18 @@ describe('processWithHybridBatch', () => {
     createBatchJob.mockRejectedValue(new Error('boom'));
     await expect(processWithHybridBatch(['Acme LLC'], 'batch')).rejects.toThrow('Failed to create batch job: boom');
   });
+
+  it('handles invalid names without sending them to AI', async () => {
+    optimizedBatchClassification.mockResolvedValue([
+      { payeeName: 'Acme LLC', classification: 'Business', confidence: 98, reasoning: 'mock' }
+    ]);
+
+    const result = await processWithHybridBatch(['Acme LLC', '' as any], 'realtime');
+
+    expect(optimizedBatchClassification).toHaveBeenCalledWith(['Acme LLC'], 30000);
+    expect(result.results[1].processingTier).toBe('Failed');
+    expect(result.results[1].reasoning).toContain('Invalid payee name');
+  });
 });
 
 describe('completeBatchJob', () => {

--- a/tests/keywordExclusion.invalidInput.test.ts
+++ b/tests/keywordExclusion.invalidInput.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { checkKeywordExclusion, filterPayeeNames } from '@/lib/classification/keywordExclusion';
+
+describe('checkKeywordExclusion invalid input handling', () => {
+  it('returns not excluded for invalid input', () => {
+    const result = checkKeywordExclusion(undefined as any);
+    expect(result.isExcluded).toBe(false);
+    expect(result.matchedKeywords).toHaveLength(0);
+  });
+});
+
+describe('filterPayeeNames invalid input handling', () => {
+  it('skips invalid names', () => {
+    const { validNames, excludedNames } = filterPayeeNames([
+      'Qwerty',
+      '',
+      '  ',
+      null as any
+    ]);
+    expect(validNames).toEqual(['Qwerty']);
+    expect(excludedNames).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- prevent invalid payee names from being marked as keyword exclusions
- skip invalid names during filtering and hybrid batch processing
- add tests for invalid-input scenarios

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any. Specify a different type)*

------
https://chatgpt.com/codex/tasks/task_e_68a75a0559fc83218c61809e44fbdff3