### PR TITLE
Classify excluded payees as business

### DIFF
--- a/src/lib/classification/enhancedBatchProcessor.ts
+++ b/src/lib/classification/enhancedBatchProcessor.ts
@@ -75,8 +75,8 @@ export async function enhancedProcessBatch(
       const originalIndex = validPayeeNames.indexOf(name);
       if (originalIndex !== -1) {
         results[originalIndex] = {
-          classification: 'Individual', // Default for excluded
-          confidence: 0,
+          classification: 'Business',
+          confidence: 95,
           reasoning: `Excluded due to keywords: ${reason.join(', ')}`,
           processingTier: 'Excluded'
         };

--- a/src/lib/classification/enhancedClassificationV2.ts
+++ b/src/lib/classification/enhancedClassificationV2.ts
@@ -26,7 +26,7 @@ export async function enhancedClassifyPayeeV2(
   const exclusionResult = checkKeywordExclusion(payeeName);
   if (exclusionResult.isExcluded) {
     return {
-      classification: 'Individual',
+      classification: 'Business',
       confidence: 95,
       reasoning: `Excluded by keyword filter: ${exclusionResult.matchedKeywords?.join(", ")}`,
       processingTier: 'Excluded',

--- a/tests/enhancedBatchProcessor.test.ts
+++ b/tests/enhancedBatchProcessor.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { enhancedProcessBatch } from '@/lib/classification/enhancedBatchProcessor';
+
+describe('enhancedProcessBatch', () => {
+  it('marks excluded names as business entities', async () => {
+    const names = ['Bank of Test'];
+    const results = await enhancedProcessBatch(names);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].classification).toBe('Business');
+    expect(results[0].processingTier).toBe('Excluded');
+  });
+});
+


### PR DESCRIPTION
## Summary
- Ensure excluded payees are tagged as `Business` with high confidence in batch processing
- Align V2 classifier exclusions with new `Business` classification
- Add test verifying excluded names are handled as business entities

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, ban-ts-comment, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68a75a0429448321987674b65864384a