### PR TITLE
feat: add prompt version to cache

### DIFF
--- a/src/lib/classification/config.ts
+++ b/src/lib/classification/config.ts
@@ -19,6 +19,9 @@ export const DEFAULT_CLASSIFICATION_CONFIG: ClassificationConfig = {
   useCacheForDuplicates: true // Deduplicate similar names
 };
 
+// Version identifier for AI classification prompts
+export const promptVersion = '1';
+
 // Increased concurrency limits for better parallel processing
 const envConcurrency = parseInt(getEnvVar('CLASSIFIER_MAX_CONCURRENCY', '20'), 10);
 export const MAX_CONCURRENCY =


### PR DESCRIPTION
## Summary
- add promptVersion constant for AI classification prompts
- include promptVersion in classification cache entries and invalidate old versions

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a75e328e7883218cefcc74c78b59c6