### PR TITLE
feat: add token-aware batch preprocessing

### DIFF
--- a/src/lib/openai/config.ts
+++ b/src/lib/openai/config.ts
@@ -16,6 +16,16 @@ const envBatchSize = parseInt(getEnvVar('OPENAI_MAX_BATCH_SIZE', '15'), 10);
 export const MAX_BATCH_SIZE =
   Number.isFinite(envBatchSize) && envBatchSize > 0 ? envBatchSize : 15; // Increased for better throughput
 
+// Maximum tokens allowed per request (prompt + completion)
+const envMaxTokens = parseInt(getEnvVar('OPENAI_MAX_TOKENS', '2000'), 10);
+export const MAX_TOKENS =
+  Number.isFinite(envMaxTokens) && envMaxTokens > 0 ? envMaxTokens : 2000;
+
+// Maximum number of items sent in a single request
+const envMaxItems = parseInt(getEnvVar('OPENAI_MAX_ITEMS_PER_REQUEST', '10'), 10);
+export const MAX_ITEMS_PER_REQUEST =
+  Number.isFinite(envMaxItems) && envMaxItems > 0 ? envMaxItems : 10;
+
 // Use the most reliable and fast model
 export const CLASSIFICATION_MODEL = 'gpt-4o-mini';
 


### PR DESCRIPTION
## Summary
- add configurable token and item ceilings for OpenAI requests
- truncate payee descriptions and estimate tokens to keep batches within limits
- resize batches based on token estimates to stay under model ceilings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a75e3476e883218081bc5b5492dcec