### PR TITLE
Handle apostrophes and hyphens in name normalization

### DIFF
--- a/src/lib/classification/nameProcessing.ts
+++ b/src/lib/classification/nameProcessing.ts
@@ -16,8 +16,8 @@ export function normalizePayeeName(name: string): string {
     .toUpperCase()
     // Normalize UTF-8 characters
     .normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-    // Remove common punctuation
-    .replace(/[.,/#!$%^&*;:{}=\-_`~()]/g, ' ')
+    // Remove common punctuation including apostrophes and hyphens
+    .replace(/[-\\',./#!$%^&*;:{}=_`~()]/g, ' ')
     // Replace multiple spaces with a single space
     .replace(/\s+/g, ' ')
     // Trim leading/trailing whitespace

--- a/tests/nameProcessing.test.ts
+++ b/tests/nameProcessing.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { normalizePayeeName } from '@/lib/classification/nameProcessing';
+
+describe('normalizePayeeName punctuation handling', () => {
+  it('normalizes names with apostrophes to match those without', () => {
+    const withApostrophe = normalizePayeeName("O'Brien Corp");
+    const withoutApostrophe = normalizePayeeName('O Brien');
+    expect(withApostrophe).toBe(withoutApostrophe);
+  });
+
+  it('normalizes names with hyphens to match those without', () => {
+    const withHyphen = normalizePayeeName('Acme-Co');
+    const withoutHyphen = normalizePayeeName('Acme Co');
+    expect(withHyphen).toBe(withoutHyphen);
+  });
+});


### PR DESCRIPTION
## Summary
- expand normalization regex to strip apostrophes and hyphens
- add tests verifying names with apostrophes or hyphens normalize correctly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7620ef0ac8321bc7506b83b66835a