### PR TITLE
Handle invalid payee names in AI classification

### DIFF
--- a/src/lib/classification/aiClassification.ts
+++ b/src/lib/classification/aiClassification.ts
@@ -6,6 +6,17 @@ import { ClassificationResult } from '../types';
  * This provides intelligent classification without requiring external API keys
  */
 export async function applyAIClassification(payeeName: string): Promise<ClassificationResult> {
+  // Validate input
+  if (typeof payeeName !== 'string' || payeeName.trim().length === 0) {
+    return {
+      classification: 'Unknown',
+      confidence: 0,
+      reasoning: 'Invalid or empty payee name provided.',
+      processingTier: 'AI-Assisted' as const,
+      matchingRules: []
+    };
+  }
+
   // Simulate AI processing time
   await new Promise(resolve => setTimeout(resolve, 100));
   

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 
 export interface ClassificationResult {
-  classification: 'Business' | 'Individual';
+  classification: 'Business' | 'Individual' | 'Unknown';
   confidence: number;
   reasoning: string;
   processingTier: 'Rule-Based' | 'NLP-Based' | 'AI-Assisted' | 'AI-Powered' | 'Excluded' | 'Failed';

--- a/tests/aiClassification.test.ts
+++ b/tests/aiClassification.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { applyAIClassification } from '../src/lib/classification/aiClassification.ts';
+
+describe('applyAIClassification input validation', () => {
+  it('returns Unknown for empty string', async () => {
+    const result = await applyAIClassification('');
+    expect(result.classification).toBe('Unknown');
+    expect(result.confidence).toBeLessThan(50);
+    expect(result.reasoning).toMatch(/invalid/i);
+  });
+
+  it('returns Unknown for non-string input', async () => {
+    const result = await applyAIClassification(undefined as unknown as string);
+    expect(result.classification).toBe('Unknown');
+    expect(result.confidence).toBeLessThan(50);
+    expect(result.reasoning).toMatch(/invalid/i);
+  });
+});


### PR DESCRIPTION
## Summary
- Validate `payeeName` in `applyAIClassification` and return an `Unknown` result with low confidence when input is invalid
- Allow `Unknown` classification in `ClassificationResult`
- Add unit tests for invalid `applyAIClassification` inputs

## Testing
- `npm test`
- `npm run lint` *(fails: 143 problems (130 errors, 13 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68a7643558088321ad20e77dbb3a3743