### PR TITLE
Align exporter headers and add tests

### DIFF
--- a/src/lib/classification/exporters/fallbackExporter.ts
+++ b/src/lib/classification/exporters/fallbackExporter.ts
@@ -7,20 +7,44 @@ import { ExportRow } from './types';
  */
 export function createFallbackExportData(results: any[]): ExportRow[] {
   logger.info('[FALLBACK EXPORTER] No original file data, creating export from results only');
-  
-  return results.map(result => ({
-    'Payee_Name': result.payeeName,
-    'Classification': result.result.classification,
-    'Confidence_%': result.result.confidence,
-    'Processing_Tier': result.result.processingTier,
-    'Reasoning': result.result.reasoning,
-    'Processing_Method': result.result.processingMethod || 'Unknown',
-    'Keyword_Exclusion': result.result.keywordExclusion?.isExcluded ? 'Yes' : 'No',
-    'Matched_Keywords': result.result.keywordExclusion?.matchedKeywords?.join('; ') || '',
-    'Keyword_Confidence_%': result.result.keywordExclusion?.confidence || 0,
-    'Keyword_Reasoning': result.result.keywordExclusion?.reasoning || 'No keyword exclusion applied',
-    'Matching_Rules': result.result.matchingRules?.join('; ') || '',
-    'Classification_Timestamp': result.timestamp.toISOString(),
-    'Row_Index': result.rowIndex || 0
-  }));
+
+  return results.map((result, index) => {
+    const exportRow: ExportRow = {
+      'Payee_Name': result.payeeName,
+      'AI_Classification': result.result.classification,
+      'AI_Confidence_%': result.result.confidence,
+      'AI_Processing_Tier': result.result.processingTier,
+      'AI_Reasoning': result.result.reasoning,
+      'AI_Processing_Method': result.result.processingMethod || 'Unknown',
+      'Keyword_Exclusion': result.result.keywordExclusion?.isExcluded ? 'Yes' : 'No',
+      'Matched_Keywords': result.result.keywordExclusion?.matchedKeywords?.join('; ') || '',
+      'Keyword_Confidence_%': result.result.keywordExclusion?.confidence || 0,
+      'Keyword_Reasoning': result.result.keywordExclusion?.reasoning || 'No keyword exclusion applied',
+      'Matching_Rules': result.result.matchingRules?.join('; ') || '',
+      'Similarity_Scores': '',
+      'Classification_Timestamp': result.timestamp.toISOString(),
+      'Processing_Row_Index': result.rowIndex ?? index,
+      'Data_Alignment_Status': 'No Original Data Available'
+    };
+
+    const similarityDetails: string[] = [];
+    if (result.result.similarityScores?.levenshtein) {
+      similarityDetails.push(`Levenshtein: ${result.result.similarityScores.levenshtein}`);
+    }
+    if (result.result.similarityScores?.jaroWinkler) {
+      similarityDetails.push(`Jaro-Winkler: ${result.result.similarityScores.jaroWinkler}`);
+    }
+    if (result.result.similarityScores?.dice) {
+      similarityDetails.push(`Dice: ${result.result.similarityScores.dice}`);
+    }
+    if (result.result.similarityScores?.tokenSort) {
+      similarityDetails.push(`Token Sort: ${result.result.similarityScores.tokenSort}`);
+    }
+    if (result.result.similarityScores?.combined) {
+      similarityDetails.push(`Combined: ${result.result.similarityScores.combined}`);
+    }
+    exportRow['Similarity_Scores'] = similarityDetails.join(' | ') || '';
+
+    return exportRow;
+  });
 }

--- a/src/lib/classification/fixedExporter.ts
+++ b/src/lib/classification/fixedExporter.ts
@@ -39,28 +39,54 @@ export function exportResultsFixed(
     // Create export row with original data first
     const exportRow: any = includeAllColumns ? { ...originalRow } : {};
     
-    // Add classification results
+    // Add classification results (matching resultsMerger.ts column names)
     exportRow['AI_Classification'] = result.result.classification;
-    exportRow['AI_Confidence'] = `${result.result.confidence}%`;
+    exportRow['AI_Confidence_%'] = result.result.confidence;
+    exportRow['AI_Processing_Tier'] = result.result.processingTier;
     exportRow['AI_Reasoning'] = result.result.reasoning;
-    exportRow['Processing_Method'] = result.result.processingMethod;
-    exportRow['Processing_Tier'] = result.result.processingTier;
-    exportRow['Payee_Name_Used'] = result.payeeName;
-    
-    // Add keyword exclusion details if it was excluded
-    if (result.result.processingTier === 'Excluded') {
-      exportRow['Keyword_Excluded'] = 'YES';
-      exportRow['Exclusion_Reason'] = result.result.reasoning;
-      exportRow['Matched_Keywords'] = result.result.keywordExclusion?.matchedKeywords?.join('; ') || '';
-    } else {
-      exportRow['Keyword_Excluded'] = 'NO';
-      exportRow['Exclusion_Reason'] = 'Not excluded by keywords';
-      exportRow['Matched_Keywords'] = '';
+    exportRow['AI_Processing_Method'] = result.result.processingMethod;
+
+    // Keyword exclusion details
+    exportRow['Keyword_Exclusion'] = result.result.keywordExclusion?.isExcluded ? 'Yes' : 'No';
+    exportRow['Matched_Keywords'] = result.result.keywordExclusion?.matchedKeywords?.join('; ') || '';
+    exportRow['Keyword_Confidence_%'] = result.result.keywordExclusion?.confidence || 0;
+    exportRow['Keyword_Reasoning'] =
+      result.result.keywordExclusion?.reasoning || 'No keyword exclusion applied';
+
+    // Enhanced classification details
+    exportRow['Matching_Rules'] = result.result.matchingRules?.join('; ') || '';
+
+    // Similarity scores
+    const similarityDetails: string[] = [];
+    if (result.result.similarityScores?.levenshtein) {
+      similarityDetails.push(
+        `Levenshtein: ${result.result.similarityScores.levenshtein}`
+      );
     }
-    
-    // Add processing timestamp
-    exportRow['Processed_At'] = result.timestamp.toISOString();
-    exportRow['Data_Source'] = 'Full File Processing (original structure preserved)';
+    if (result.result.similarityScores?.jaroWinkler) {
+      similarityDetails.push(
+        `Jaro-Winkler: ${result.result.similarityScores.jaroWinkler}`
+      );
+    }
+    if (result.result.similarityScores?.dice) {
+      similarityDetails.push(`Dice: ${result.result.similarityScores.dice}`);
+    }
+    if (result.result.similarityScores?.tokenSort) {
+      similarityDetails.push(
+        `Token Sort: ${result.result.similarityScores.tokenSort}`
+      );
+    }
+    if (result.result.similarityScores?.combined) {
+      similarityDetails.push(
+        `Combined: ${result.result.similarityScores.combined}`
+      );
+    }
+    exportRow['Similarity_Scores'] = similarityDetails.join(' | ') || '';
+
+    // Timestamps and metadata
+    exportRow['Classification_Timestamp'] = result.timestamp.toISOString();
+    exportRow['Processing_Row_Index'] = result.rowIndex ?? i;
+    exportRow['Data_Alignment_Status'] = 'Perfect 1:1 Match';
     
     exportData.push(exportRow);
   }
@@ -91,31 +117,60 @@ export function exportResultsFromClassifications(
     if (result.originalData && Object.keys(result.originalData).length > 0) {
       Object.assign(exportRow, result.originalData);
     } else {
-      exportRow['Row_Number'] = index + 1;
+      exportRow['Processing_Row_Index'] = index;
       exportRow['Payee_Name'] = result.payeeName;
     }
     
     // Add classification results
     exportRow['AI_Classification'] = result.result.classification;
-    exportRow['AI_Confidence'] = `${result.result.confidence}%`;
+    exportRow['AI_Confidence_%'] = result.result.confidence;
+    exportRow['AI_Processing_Tier'] = result.result.processingTier;
     exportRow['AI_Reasoning'] = result.result.reasoning;
-    exportRow['Processing_Method'] = result.result.processingMethod || 'OpenAI Batch API';
-    exportRow['Processing_Tier'] = result.result.processingTier;
-    
-    // Add keyword exclusion details
-    if (result.result.processingTier === 'Excluded') {
-      exportRow['Keyword_Excluded'] = 'YES';
-      exportRow['Exclusion_Reason'] = result.result.reasoning;
-      exportRow['Matched_Keywords'] = result.result.keywordExclusion?.matchedKeywords?.join('; ') || '';
-    } else {
-      exportRow['Keyword_Excluded'] = 'NO';
-      exportRow['Exclusion_Reason'] = 'Not excluded by keywords';
-      exportRow['Matched_Keywords'] = '';
+    exportRow['AI_Processing_Method'] =
+      result.result.processingMethod || 'OpenAI Batch API';
+
+    // Keyword exclusion details
+    exportRow['Keyword_Exclusion'] = result.result.keywordExclusion?.isExcluded ? 'Yes' : 'No';
+    exportRow['Matched_Keywords'] = result.result.keywordExclusion?.matchedKeywords?.join('; ') || '';
+    exportRow['Keyword_Confidence_%'] = result.result.keywordExclusion?.confidence || 0;
+    exportRow['Keyword_Reasoning'] =
+      result.result.keywordExclusion?.reasoning || 'No keyword exclusion applied';
+
+    // Enhanced classification details
+    exportRow['Matching_Rules'] = result.result.matchingRules?.join('; ') || '';
+
+    // Similarity scores
+    const similarityDetails: string[] = [];
+    if (result.result.similarityScores?.levenshtein) {
+      similarityDetails.push(
+        `Levenshtein: ${result.result.similarityScores.levenshtein}`
+      );
     }
-    
-    // Add processing timestamp
-    exportRow['Processed_At'] = result.timestamp.toISOString();
-    exportRow['Data_Source'] = 'Fallback Export (original data not preserved - should not happen)';
+    if (result.result.similarityScores?.jaroWinkler) {
+      similarityDetails.push(
+        `Jaro-Winkler: ${result.result.similarityScores.jaroWinkler}`
+      );
+    }
+    if (result.result.similarityScores?.dice) {
+      similarityDetails.push(`Dice: ${result.result.similarityScores.dice}`);
+    }
+    if (result.result.similarityScores?.tokenSort) {
+      similarityDetails.push(
+        `Token Sort: ${result.result.similarityScores.tokenSort}`
+      );
+    }
+    if (result.result.similarityScores?.combined) {
+      similarityDetails.push(
+        `Combined: ${result.result.similarityScores.combined}`
+      );
+    }
+    exportRow['Similarity_Scores'] = similarityDetails.join(' | ') || '';
+
+    // Timestamps and metadata
+    exportRow['Classification_Timestamp'] = result.timestamp.toISOString();
+    exportRow['Processing_Row_Index'] = result.rowIndex ?? index;
+    exportRow['Data_Alignment_Status'] =
+      'Fallback Export (original data not preserved - should not happen)';
     
     return exportRow;
   });

--- a/src/lib/classification/ruleBasedClassification.ts
+++ b/src/lib/classification/ruleBasedClassification.ts
@@ -1,4 +1,13 @@
 import { logger } from '../logger';
+import { ClassificationResult } from '../types';
+import {
+  LEGAL_SUFFIXES,
+  BUSINESS_KEYWORDS,
+  INDUSTRY_IDENTIFIERS,
+  GOVERNMENT_PATTERNS,
+  PROFESSIONAL_TITLES
+} from './config';
+import { probablepeople } from './probablepeople';
 
 /**
  * Rule-based classification using probablepeople library and custom rules

--- a/tests/exporterHeaders.test.ts
+++ b/tests/exporterHeaders.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import { exportResultsFixed } from '@/lib/classification/fixedExporter';
+import {
+  exportResultsWithOriginalDataV3,
+  createFallbackExportData
+} from '@/lib/classification/exporters';
+
+const baseResult = {
+  payeeName: 'Acme LLC',
+  result: {
+    classification: 'Business',
+    confidence: 95,
+    reasoning: 'reason',
+    processingTier: 'AI-Powered',
+    processingMethod: 'OpenAI',
+    keywordExclusion: {
+      isExcluded: false,
+      matchedKeywords: [],
+      confidence: 0,
+      reasoning: 'No keyword exclusion applied'
+    },
+    matchingRules: ['rule1'],
+    similarityScores: { levenshtein: 0.8 }
+  },
+  timestamp: new Date('2024-01-01T00:00:00Z'),
+  rowIndex: 0
+};
+
+describe('exporter column headers', () => {
+  const batch = {
+    results: [baseResult],
+    successCount: 1,
+    failureCount: 0,
+    originalFileData: [{ Payee_Name: 'Acme LLC' }]
+  };
+
+  const expectedHeaders = [
+    'Payee_Name',
+    'AI_Classification',
+    'AI_Confidence_%',
+    'AI_Processing_Tier',
+    'AI_Reasoning',
+    'AI_Processing_Method',
+    'Keyword_Exclusion',
+    'Matched_Keywords',
+    'Keyword_Confidence_%',
+    'Keyword_Reasoning',
+    'Matching_Rules',
+    'Similarity_Scores',
+    'Classification_Timestamp',
+    'Processing_Row_Index',
+    'Data_Alignment_Status'
+  ];
+
+  it('all exporters produce identical headers', () => {
+    const merged = exportResultsWithOriginalDataV3(batch, true);
+    const fixed = exportResultsFixed(batch, true);
+    const fallback = createFallbackExportData(batch.results);
+
+    expect(Object.keys(merged[0])).toEqual(expectedHeaders);
+    expect(Object.keys(fixed[0])).toEqual(expectedHeaders);
+    expect(Object.keys(fallback[0])).toEqual(expectedHeaders);
+  });
+});


### PR DESCRIPTION
## Summary
- Align fixed and fallback exporters with resultsMerger column names
- Fix missing rule-based classifier imports
- Add tests ensuring all exporters share identical column headers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a769fde7e08321acd58c69ee04b9e5