### PR TITLE
feat: extend batch progress tracking

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import Index from "./pages/Index";
 import About from "./pages/About";
 import NotFound from "./pages/NotFound";
+import BatchStatus from "./pages/BatchStatus";
 
 const queryClient = new QueryClient();
 
@@ -26,6 +27,7 @@ const App = () => {
               <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/about" element={<About />} />
+                <Route path="/batches/:id" element={<BatchStatus />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />
               </Routes>

--- a/src/api/server.ts
+++ b/src/api/server.ts
@@ -7,7 +7,9 @@ export interface BatchProgress {
   queued: number;
   running: number;
   failed: number;
-  eta: number | null;
+  low_confidence: number;
+  duplicates_found: number;
+  eta_seconds: number | null;
 }
 
 const DEFAULT_STATUS: BatchProgress = {
@@ -16,7 +18,9 @@ const DEFAULT_STATUS: BatchProgress = {
   queued: 0,
   running: 0,
   failed: 0,
-  eta: null
+  low_confidence: 0,
+  duplicates_found: 0,
+  eta_seconds: null
 };
 
 const batchStatuses: Map<string, BatchProgress> = new Map();

--- a/src/components/LiveProgressDashboard.tsx
+++ b/src/components/LiveProgressDashboard.tsx
@@ -45,7 +45,13 @@ const LiveProgressDashboard = () => {
           const estimatedTotal = job.processingSpeed && job.processingSpeed > 0
             ? (job.totalRows / job.processingSpeed) * 60
             : 0;
-          const remainingTime = job.eta ?? (estimatedTotal - elapsedTime);
+          const remainingTime = job.etaSeconds ?? (estimatedTotal - elapsedTime);
+          const lowConfidencePct = job.totalRows > 0
+            ? ((job.lowConfidence ?? 0) / job.totalRows) * 100
+            : 0;
+          const duplicatesPct = job.totalRows > 0
+            ? ((job.duplicatesFound ?? 0) / job.totalRows) * 100
+            : 0;
 
           return (
             <div key={job.id} className="border rounded-lg p-4 space-y-3">
@@ -107,6 +113,27 @@ const LiveProgressDashboard = () => {
                   <div className="w-2 h-2 bg-red-500 rounded-full"></div>
                   <span>Failed: {job.failed ?? 0}</span>
                 </div>
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex justify-between text-sm text-muted-foreground">
+                  <span>Low confidence: {job.lowConfidence ?? 0}</span>
+                  <span>{lowConfidencePct.toFixed(1)}%</span>
+                </div>
+                <Progress value={lowConfidencePct} className="h-2" />
+              </div>
+
+              <div className="space-y-2">
+                <div className="flex justify-between text-sm text-muted-foreground">
+                  <span>Duplicates: {job.duplicatesFound ?? 0}</span>
+                  <span>{duplicatesPct.toFixed(1)}%</span>
+                </div>
+                <Progress value={duplicatesPct} className="h-2" />
+              </div>
+
+              <div className="flex gap-2">
+                <Button size="sm" variant="secondary">Review Low Confidence</Button>
+                <Button size="sm" variant="secondary">Review Duplicates</Button>
               </div>
 
               {job.status === 'running' && remainingTime > 0 && (

--- a/src/contexts/ProcessingContext.tsx
+++ b/src/contexts/ProcessingContext.tsx
@@ -24,7 +24,9 @@ export interface ProcessingJob {
   queued?: number;
   running?: number;
   failed?: number;
-  eta?: number | null;
+  lowConfidence?: number;
+  duplicatesFound?: number;
+  etaSeconds?: number | null;
   statusUrl?: string;
   progressUrl?: string;
 }
@@ -81,8 +83,10 @@ export const ProcessingProvider: React.FC<{ children: React.ReactNode }> = ({ ch
           queued: data.queued,
           running: data.running,
           failed: data.failed,
-          estimatedTimeRemaining: data.eta ?? undefined,
-          eta: data.eta,
+          lowConfidence: data.low_confidence,
+          duplicatesFound: data.duplicates_found,
+          estimatedTimeRemaining: data.eta_seconds ?? undefined,
+          etaSeconds: data.eta_seconds,
           status
         });
 

--- a/src/pages/BatchStatus.tsx
+++ b/src/pages/BatchStatus.tsx
@@ -1,0 +1,101 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+import { Button } from "@/components/ui/button";
+
+interface BatchProgress {
+  rows_total: number;
+  rows_done: number;
+  queued: number;
+  running: number;
+  failed: number;
+  low_confidence: number;
+  duplicates_found: number;
+  eta_seconds: number | null;
+}
+
+function useBatchStatus(id: string) {
+  const [status, setStatus] = useState<BatchProgress | null>(null);
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setInterval>;
+
+    const fetchStatus = async () => {
+      try {
+        const res = await fetch(`/api/batches/${id}/status`);
+        if (res.ok) {
+          const data = await res.json();
+          setStatus(data);
+        }
+      } catch {
+        // ignore errors
+      }
+    };
+
+    fetchStatus();
+    timer = setInterval(fetchStatus, 5000);
+    return () => clearInterval(timer);
+  }, [id]);
+
+  return status;
+}
+
+export default function BatchStatus() {
+  const { id = "" } = useParams<{ id: string }>();
+  const status = useBatchStatus(id);
+
+  if (!status) {
+    return <div>Loading...</div>;
+  }
+
+  const progress = status.rows_total > 0 ? (status.rows_done / status.rows_total) * 100 : 0;
+  const lowConfPct = status.rows_total > 0 ? (status.low_confidence / status.rows_total) * 100 : 0;
+  const dupPct = status.rows_total > 0 ? (status.duplicates_found / status.rows_total) * 100 : 0;
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-3xl">
+      <Card>
+        <CardHeader>
+          <CardTitle>Batch {id.slice(-8)}</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm text-muted-foreground">
+              <span>Progress: {status.rows_done} / {status.rows_total}</span>
+              <span>{progress.toFixed(1)}%</span>
+            </div>
+            <Progress value={progress} className="h-2" />
+          </div>
+
+          <div className="grid grid-cols-2 md:grid-cols-3 gap-4 text-sm">
+            <div>Queued: {status.queued}</div>
+            <div>Running: {status.running}</div>
+            <div>Failed: {status.failed}</div>
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm text-muted-foreground">
+              <span>Low confidence: {status.low_confidence}</span>
+              <span>{lowConfPct.toFixed(1)}%</span>
+            </div>
+            <Progress value={lowConfPct} className="h-2" />
+          </div>
+
+          <div className="space-y-2">
+            <div className="flex justify-between text-sm text-muted-foreground">
+              <span>Duplicates: {status.duplicates_found}</span>
+              <span>{dupPct.toFixed(1)}%</span>
+            </div>
+            <Progress value={dupPct} className="h-2" />
+          </div>
+
+          <div className="flex gap-2">
+            <Button variant="secondary" size="sm">Review Low Confidence</Button>
+            <Button variant="secondary" size="sm">Review Duplicates</Button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/workers/batchProgressWorker.ts
+++ b/src/workers/batchProgressWorker.ts
@@ -1,0 +1,27 @@
+import { updateBatchStatus } from "@/api/server";
+
+export interface WorkerProgress {
+  rowsDone: number;
+  queued: number;
+  running: number;
+  failed: number;
+  lowConfidence: number;
+  duplicatesFound: number;
+  etaSeconds: number | null;
+}
+
+/**
+ * Report batch processing progress back to the server.
+ * Workers should call this function whenever their counters change.
+ */
+export function reportProgress(id: string, progress: WorkerProgress) {
+  updateBatchStatus(id, {
+    rows_done: progress.rowsDone,
+    queued: progress.queued,
+    running: progress.running,
+    failed: progress.failed,
+    low_confidence: progress.lowConfidence,
+    duplicates_found: progress.duplicatesFound,
+    eta_seconds: progress.etaSeconds,
+  });
+}


### PR DESCRIPTION
## Summary
- track low-confidence and duplicate counts with ETA in server batch progress
- expose new counters through processing context and dashboard UI
- add batch status page with polling hook and worker helper for progress updates

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a770dc07a4832183833840493556c6