### PR TITLE
feat: track prompt version for classifications

### DIFF
--- a/src/lib/backend/index.ts
+++ b/src/lib/backend/index.ts
@@ -33,6 +33,7 @@ export interface UploadRowRecord {
 
 export interface ClassificationRecord {
   row_id: number;
+  prompt_version: number;
   classification: PayeeClassification['result'];
 }
 
@@ -67,7 +68,7 @@ export async function upsertClassifications(records: ClassificationRecord[]): Pr
   if (!records.length) return;
   const { error } = await supabase
     .from('classifications')
-    .upsert(records, { onConflict: 'row_id' });
+    .upsert(records, { onConflict: 'row_id,prompt_version' });
   if (error) throw error;
 }
 

--- a/src/lib/storage/resultStorage.ts
+++ b/src/lib/storage/resultStorage.ts
@@ -8,6 +8,9 @@ import {
   supabase,
 } from '@/lib/backend';
 
+// Version of the classification prompt used when storing results
+const PROMPT_VERSION = 1;
+
 export { isSupabaseConfigured } from '@/lib/backend';
 
 export interface StoredBatchResult {
@@ -67,11 +70,13 @@ export const saveProcessingResults = async (
 
   const insertedRows = await upsertUploadRows(rows);
 
-  const classificationRecords = insertedRows.map((row, idx) => ({
+  // Buffer classifications in memory and persist in a single batch
+  const classificationBuffer = insertedRows.map((row, idx) => ({
     row_id: row.id as number,
+    prompt_version: PROMPT_VERSION,
     classification: results[idx].result,
   }));
-  await upsertClassifications(classificationRecords);
+  await upsertClassifications(classificationBuffer);
 
   console.log(`[RESULT STORAGE] Successfully saved results with batch ID: ${batchId}`);
   return batchId;
@@ -95,7 +100,7 @@ export const getResultById = async (id: string): Promise<StoredBatchResult | nul
 
   const { data: rows, error: rowsError } = await supabase!
     .from('upload_rows')
-    .select('id, row_index, payee_name, original_data, classifications(classification)')
+    .select('id, row_index, payee_name, original_data, classifications(classification,prompt_version)')
     .eq('batch_id', id)
     .order('row_index', { ascending: true });
   if (rowsError) {

--- a/supabase/migrations/20241006000000_add_prompt_version_to_classifications.sql
+++ b/supabase/migrations/20241006000000_add_prompt_version_to_classifications.sql
@@ -1,0 +1,11 @@
+-- Add prompt_version to classifications table and update unique constraint
+alter table classifications
+  add column prompt_version integer not null default 1;
+
+alter table classifications
+  drop constraint if exists classifications_row_id_key;
+
+alter table classifications
+  add constraint classifications_row_id_prompt_version_key unique (row_id, prompt_version);
+
+create index if not exists idx_classifications_prompt_version on classifications(prompt_version);


### PR DESCRIPTION
## Summary
- add `prompt_version` column to `classifications` table with composite unique key
- batch upsert classification records using `row_id,prompt_version`
- persist classifications once per batch with prompt version metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a770dd9c748321879ed4a4598e5bd7