### PR TITLE
Add rule pre-checks and micro-batched classification

### DIFF
--- a/src/lib/openai/schema.ts
+++ b/src/lib/openai/schema.ts
@@ -1,0 +1,12 @@
+import { z } from 'zod';
+
+export const classificationResponseSchema = z.array(
+  z.object({
+    name: z.string(),
+    classification: z.enum(['Business', 'Individual']),
+    confidence: z.number().min(0).max(100),
+    reasoning: z.string()
+  })
+);
+
+export type ClassificationResponse = z.infer<typeof classificationResponseSchema>;


### PR DESCRIPTION
## Summary
- run rule-based classifier in V3 batch processor and short-circuit high confidence names
- micro-batch uncached names (10-20) with Zod-validated responses and retries
- cache OpenAI batch results by normalized name and prompt version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a770d93bd08321a06a69259e853989