### PR TITLE
refactor: replace console with logger

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,6 @@ import BatchStatus from "./pages/BatchStatus";
 const queryClient = new QueryClient();
 
 const App = () => {
-  console.log('[APP] App component rendering...');
   
   return (
     <ErrorBoundary>

--- a/src/components/APIKeyInput.tsx
+++ b/src/components/APIKeyInput.tsx
@@ -7,6 +7,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { isOpenAIInitialized, initializeOpenAI, testOpenAIConnection, clearOpenAIKeys } from "@/lib/openai/client";
 import { useToast } from "@/components/ui/use-toast";
 import { CheckCircle, Key, Eye, EyeOff, Loader2, AlertTriangle } from "lucide-react";
+import { logger } from '@/lib/logger';
 
 interface APIKeyInputProps {
   onApiKeySet: () => void;
@@ -26,7 +27,7 @@ const APIKeyInput = ({ onApiKeySet, onApiKeyChange }: APIKeyInputProps) => {
   // Test if OpenAI is already working on component mount
   useEffect(() => {
     const testConnection = async () => {
-      console.log('[API_KEY_INPUT] Testing existing connection...');
+      logger.info('[API_KEY_INPUT] Testing existing connection...');
       
       if (isOpenAIInitialized()) {
         try {
@@ -37,7 +38,7 @@ const APIKeyInput = ({ onApiKeySet, onApiKeyChange }: APIKeyInputProps) => {
           );
           
           const isWorking = await Promise.race([testPromise, timeoutPromise]);
-          console.log('[API_KEY_INPUT] Connection test result:', isWorking);
+          logger.info('[API_KEY_INPUT] Connection test result:', isWorking);
           
           if (isWorking) {
             setConnectionWorking(true);
@@ -53,11 +54,11 @@ const APIKeyInput = ({ onApiKeySet, onApiKeyChange }: APIKeyInputProps) => {
             setHasConnectionError(true);
           }
         } catch (error) {
-          console.log('[API_KEY_INPUT] Connection test failed or timed out:', error);
+          logger.warn('[API_KEY_INPUT] Connection test failed or timed out:', error);
           setHasConnectionError(true);
         }
       } else {
-        console.log('[API_KEY_INPUT] No API key initialized');
+        logger.info('[API_KEY_INPUT] No API key initialized');
       }
       setIsTestingConnection(false);
     };
@@ -80,11 +81,11 @@ const APIKeyInput = ({ onApiKeySet, onApiKeyChange }: APIKeyInputProps) => {
     setIsValidating(true);
     
     try {
-      console.log('[API_KEY_INPUT] Initializing with new API key...');
+      logger.info('[API_KEY_INPUT] Initializing with new API key...');
       await initializeOpenAI(apiKey.trim(), rememberKey);
       
       // Skip immediate test since initialization already validates format
-      console.log('[API_KEY_INPUT] API key initialized successfully');
+      logger.info('[API_KEY_INPUT] API key initialized successfully');
       
       toast({
         title: "API Key Set Successfully",
@@ -98,7 +99,7 @@ const APIKeyInput = ({ onApiKeySet, onApiKeyChange }: APIKeyInputProps) => {
       onApiKeySet();
       onApiKeyChange?.(); // Call the optional callback
     } catch (error) {
-      console.error("Error setting API key:", error);
+      logger.error("Error setting API key:", error);
       toast({
         title: "API Key Error",
         description: "Failed to initialize OpenAI client. Please check your API key.",

--- a/src/components/BatchResultsDisplay.tsx
+++ b/src/components/BatchResultsDisplay.tsx
@@ -8,6 +8,7 @@ import { PayeeClassification, BatchProcessingResult } from "@/lib/types";
 import { exportResultsWithOriginalDataV3 } from "@/lib/classification/exporters";
 import { exportResultsFixed } from "@/lib/classification/fixedExporter";
 import * as XLSX from 'xlsx';
+import { logger } from '@/lib/logger';
 
 interface BatchResultsDisplayProps {
   batchResults: PayeeClassification[];
@@ -37,15 +38,12 @@ const BatchResultsDisplay = ({
     }
 
     try {
-      console.log('[EXPORT] Processing summary:', processingSummary);
-      console.log('[EXPORT] Has original file data:', !!processingSummary.originalFileData);
       
       // Use custom export function if provided, otherwise use default
       const exportData = exportFunction 
         ? exportFunction(processingSummary, true)
         : exportResultsWithOriginalDataV3(processingSummary, true);
       
-      console.log('[EXPORT] Export data sample:', exportData.slice(0, 2));
       
       const workbook = XLSX.utils.book_new();
       const worksheet = XLSX.utils.json_to_sheet(exportData);
@@ -62,7 +60,7 @@ const BatchResultsDisplay = ({
         description: `Enhanced results exported to ${filename} with original file data and keyword exclusion details.`,
       });
     } catch (error) {
-      console.error("Export error:", error);
+      logger.error("Export error:", error);
       toast({
         title: "Export Error",
         description: "Failed to export results. Please try again.",

--- a/src/components/ClassificationErrorBoundary.tsx
+++ b/src/components/ClassificationErrorBoundary.tsx
@@ -3,6 +3,7 @@ import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, RefreshCw, Bug } from 'lucide-react';
+import { logger } from '@/lib/logger';
 
 interface Props {
   children: ReactNode;
@@ -36,11 +37,11 @@ class ClassificationErrorBoundary extends Component<Props, State> {
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
     const context = this.props.context || 'Classification System';
-    console.error(`[${context} ERROR BOUNDARY] Component error caught:`, error, errorInfo);
+    logger.error(`[${context} ERROR BOUNDARY] Component error caught:`, error, errorInfo);
     
     // Log specific error types
     if (error.message.includes('Maximum call stack size exceeded')) {
-      console.error('[ERROR BOUNDARY] Stack overflow detected - possible infinite loop');
+      logger.error('[ERROR BOUNDARY] Stack overflow detected - possible infinite loop');
     }
     
     this.setState({ error, errorInfo });

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -3,6 +3,7 @@ import React, { Component, ErrorInfo, ReactNode } from 'react';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
+import { logger } from '@/lib/logger';
 
 interface Props {
   children: ReactNode;
@@ -26,7 +27,7 @@ class ErrorBoundary extends Component<Props, State> {
   }
 
   componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('[ERROR BOUNDARY] Component error caught:', error, errorInfo);
+    logger.error('[ERROR BOUNDARY] Component error caught:', error, errorInfo);
     this.setState({ error, errorInfo });
   }
 

--- a/src/components/FileUploadForm.tsx
+++ b/src/components/FileUploadForm.tsx
@@ -10,6 +10,7 @@ import ColumnSelector from "./file-upload/ColumnSelector";
 import FileUploadActions from "./file-upload/FileUploadActions";
 import { BatchJob } from "@/lib/openai/trueBatchAPI";
 import { useToast } from "@/components/ui/use-toast";
+import { logger } from '@/lib/logger';
 
 interface FileUploadFormProps {
   onBatchJobCreated: (batchJob: BatchJob, payeeNames: string[], originalFileData: any[]) => void;
@@ -53,7 +54,7 @@ const FileUploadForm = ({ onBatchJobCreated, isProcessing = false }: FileUploadF
         setSelectedColumn(validationResult.payeeColumnName);
       }
     } catch (error) {
-      console.error('File validation error:', error);
+      logger.error('File validation error:', error);
       toast({
         title: "File Validation Error",
         description: error instanceof Error ? error.message : "Failed to validate file",
@@ -78,7 +79,7 @@ const FileUploadForm = ({ onBatchJobCreated, isProcessing = false }: FileUploadF
       const payeeName = String(row[selectedColumn] || '').trim();
       payeeNames.push(payeeName || '[Empty]');
     }
-    console.log(`[FILE UPLOAD] Starting batch job creation with column: ${selectedColumn}`);
+    logger.info(`[FILE UPLOAD] Starting batch job creation with column: ${selectedColumn}`);
     await submitFileForProcessing({ ...validationResult, payeeNames }, selectedColumn);
   };
 

--- a/src/components/KeywordExclusionManager.tsx
+++ b/src/components/KeywordExclusionManager.tsx
@@ -23,6 +23,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { logger } from '@/lib/logger';
 
 const KeywordExclusionManager = () => {
   const [keywords, setKeywords] = useState<string[]>([]);
@@ -38,7 +39,7 @@ const KeywordExclusionManager = () => {
       const stored = localStorage.getItem(EXCLUDED_KEYWORDS_STORAGE_KEY);
       return stored ? validateExclusionKeywords(JSON.parse(stored)) : [];
     } catch (error) {
-      console.warn("Failed to load exclusion keywords", error);
+      logger.warn("Failed to load exclusion keywords", error);
       return [];
     }
   };
@@ -47,7 +48,7 @@ const KeywordExclusionManager = () => {
     try {
       localStorage.setItem(EXCLUDED_KEYWORDS_STORAGE_KEY, JSON.stringify(list));
     } catch (error) {
-      console.warn("Failed to save exclusion keywords", error);
+      logger.warn("Failed to save exclusion keywords", error);
     }
   };
 

--- a/src/components/OpenAIDiagnostics.tsx
+++ b/src/components/OpenAIDiagnostics.tsx
@@ -6,13 +6,14 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { Wrench, CheckCircle, XCircle, AlertTriangle, RefreshCw } from "lucide-react";
-import { 
-  getOpenAIClientDiagnostics, 
-  testOpenAIConnection, 
+import {
+  getOpenAIClientDiagnostics,
+  testOpenAIConnection,
   clearOpenAIKeys,
-  isOpenAIInitialized 
+  isOpenAIInitialized
 } from "@/lib/openai/client";
 import { getApiKeyDiagnostics, clearAllApiKeys } from "@/lib/backend/apiKeyService";
+import { logger } from '@/lib/logger';
 
 interface OpenAIDiagnosticsProps {
   onReset?: () => void;
@@ -27,24 +28,24 @@ const OpenAIDiagnostics = ({ onReset }: OpenAIDiagnosticsProps) => {
   const runDiagnostics = async () => {
     setIsRunning(true);
     try {
-      console.log('[DIAGNOSTICS] Running OpenAI diagnostics...');
+      logger.info('[DIAGNOSTICS] Running OpenAI diagnostics...');
       
       const clientDiagnostics = getOpenAIClientDiagnostics();
       const storageDiagnostics = getApiKeyDiagnostics();
       const isInitialized = isOpenAIInitialized();
       
-      console.log('[DIAGNOSTICS] Client diagnostics:', clientDiagnostics);
-      console.log('[DIAGNOSTICS] Storage diagnostics:', storageDiagnostics);
-      console.log('[DIAGNOSTICS] Is initialized:', isInitialized);
+      logger.info('[DIAGNOSTICS] Client diagnostics:', clientDiagnostics);
+      logger.info('[DIAGNOSTICS] Storage diagnostics:', storageDiagnostics);
+      logger.info('[DIAGNOSTICS] Is initialized:', isInitialized);
       
       // Test connection if client appears to be initialized
       let connectionResult = null;
       if (isInitialized) {
         try {
           connectionResult = await testOpenAIConnection();
-          console.log('[DIAGNOSTICS] Connection test result:', connectionResult);
+          logger.info('[DIAGNOSTICS] Connection test result:', connectionResult);
         } catch (error) {
-          console.error('[DIAGNOSTICS] Connection test error:', error);
+          logger.error('[DIAGNOSTICS] Connection test error:', error);
           connectionResult = false;
         }
       }
@@ -64,7 +65,7 @@ const OpenAIDiagnostics = ({ onReset }: OpenAIDiagnosticsProps) => {
       });
       
     } catch (error) {
-      console.error('[DIAGNOSTICS] Diagnostics failed:', error);
+      logger.error('[DIAGNOSTICS] Diagnostics failed:', error);
       toast({
         title: "Diagnostics Failed",
         description: "Failed to run diagnostics. Check console for details.",
@@ -76,7 +77,7 @@ const OpenAIDiagnostics = ({ onReset }: OpenAIDiagnosticsProps) => {
   };
 
   const handleClearAll = () => {
-    console.log('[DIAGNOSTICS] Clearing all OpenAI data...');
+    logger.info('[DIAGNOSTICS] Clearing all OpenAI data...');
     clearOpenAIKeys();
     clearAllApiKeys();
     setDiagnostics(null);

--- a/src/components/ProcessingHistory.tsx
+++ b/src/components/ProcessingHistory.tsx
@@ -10,6 +10,7 @@ import { exportResultsFixed } from '@/lib/classification/fixedExporter';
 import { BatchProcessingResult } from '@/lib/types';
 import { useToast } from '@/components/ui/use-toast';
 import { formatDistanceToNow } from 'date-fns';
+import { logger } from '@/lib/logger';
 
 interface ProcessingHistoryProps {
   onResultSelect?: (result: StoredBatchResult) => void;
@@ -32,12 +33,10 @@ const ProcessingHistory = ({ onResultSelect }: ProcessingHistoryProps) => {
         return;
       }
       
-      console.log('[PROCESSING HISTORY] Loading history...');
       const results = await getProcessingHistory();
-      console.log('[PROCESSING HISTORY] Loaded results:', results.length);
       setHistory(results);
     } catch (error) {
-      console.error('[PROCESSING HISTORY] Failed to load history:', error);
+      logger.error('[PROCESSING HISTORY] Failed to load history:', error);
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       setError(errorMessage);
       

--- a/src/components/SingleClassificationForm.tsx
+++ b/src/components/SingleClassificationForm.tsx
@@ -12,6 +12,7 @@ import { PayeeClassification, ClassificationConfig } from "@/lib/types";
 import { useToast } from "@/components/ui/use-toast";
 import { RotateCcw } from "lucide-react";
 import { Label } from "@/components/ui/label";
+import { logger } from '@/lib/logger';
 
 interface SingleClassificationFormProps {
   onComplete?: (results: PayeeClassification[], summary?: any) => void;
@@ -54,13 +55,13 @@ const SingleClassificationForm = ({ onComplete }: SingleClassificationFormProps)
     setIsProcessing(true);
     
     try {
-      console.log(`Starting V3 classification for: ${payeeName}`);
+      logger.info(`Starting V3 classification for: ${payeeName}`);
       
       // Use V3 classification with intelligent escalation
       const result = await enhancedClassifyPayeeV3(payeeName, config);
       const classification = createPayeeClassification(payeeName, result);
       
-      console.log(`V3 Classification result:`, result);
+      logger.info(`V3 Classification result:`, result);
       
       setCurrentResult(classification);
       
@@ -74,7 +75,7 @@ const SingleClassificationForm = ({ onComplete }: SingleClassificationFormProps)
         description: `${payeeName} classified as ${result.classification} with ${result.confidence}% confidence using V3 intelligent escalation.`,
       });
     } catch (error) {
-      console.error("V3 Classification error:", error);
+      logger.error("V3 Classification error:", error);
       toast({
         title: "Classification Error",
         description: error instanceof Error ? error.message : "An error occurred while processing your request.",

--- a/src/components/batch/BatchJobActions.tsx
+++ b/src/components/batch/BatchJobActions.tsx
@@ -2,6 +2,7 @@
 import { Button } from "@/components/ui/button";
 import { RefreshCw, Download, Trash, Loader2 } from "lucide-react";
 import { BatchJob } from "@/lib/openai/trueBatchAPI";
+import { logger } from '@/lib/logger';
 
 interface BatchJobActionsProps {
   job: BatchJob;
@@ -31,7 +32,7 @@ const BatchJobActions = ({
   // Jobs that can be downloaded
   const canDownload = job.status === 'completed';
 
-  console.log(`[BATCH ACTIONS] Job ${job.id.slice(-8)} - Status: ${job.status}, canDelete: ${canDelete}, canCancel: ${canCancel}`);
+  logger.debug(`[BATCH ACTIONS] Job ${job.id.slice(-8)} - Status: ${job.status}, canDelete: ${canDelete}, canCancel: ${canCancel}`);
 
   return (
     <div className="flex gap-2 flex-wrap">

--- a/src/hooks/batch/useBatchCancel.ts
+++ b/src/hooks/batch/useBatchCancel.ts
@@ -2,6 +2,7 @@
 import { cancelBatchJob } from "@/lib/openai/trueBatchAPI";
 import { handleError, showErrorToast } from "@/lib/errorHandler";
 import { isValidBatchJobId } from "@/lib/storage/batchJobStorage";
+import { logger } from '@/lib/logger';
 
 interface UseBatchCancelProps {
   onJobUpdate: (job: any) => void;
@@ -21,7 +22,7 @@ export const useBatchCancel = ({ onJobUpdate, onJobDelete, toast }: UseBatchCanc
     }
 
     try {
-      console.log(`[BATCH MANAGER] Cancelling job ${jobId}`);
+      logger.info(`[BATCH MANAGER] Cancelling job ${jobId}`);
       const cancelledJob = await cancelBatchJob(jobId);
       onJobUpdate(cancelledJob);
       
@@ -31,7 +32,7 @@ export const useBatchCancel = ({ onJobUpdate, onJobDelete, toast }: UseBatchCanc
       });
     } catch (error) {
       const appError = handleError(error, 'Job Cancellation');
-      console.error(`[BATCH MANAGER] Error cancelling job ${jobId}:`, error);
+      logger.error(`[BATCH MANAGER] Error cancelling job ${jobId}:`, error);
       
       // Handle 404 errors specifically
       if (error instanceof Error && error.message.includes('404')) {

--- a/src/hooks/batch/useBatchRefresh.ts
+++ b/src/hooks/batch/useBatchRefresh.ts
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { checkBatchJobStatus } from "@/lib/openai/trueBatchAPI";
 import { isValidBatchJobId } from "@/lib/storage/batchJobStorage";
+import { logger } from '@/lib/logger';
 
 interface UseBatchRefreshProps {
   onJobDelete: (jobId: string) => void;
@@ -24,10 +25,10 @@ export const useBatchRefresh = ({ onJobDelete, toast }: UseBatchRefreshProps) =>
 
     setRefreshingJobs(prev => new Set(prev).add(jobId));
     try {
-      console.log(`[BATCH MANAGER] Manual refresh for job ${jobId}`);
+      logger.info(`[BATCH MANAGER] Manual refresh for job ${jobId}`);
       await manualRefresh(jobId);
     } catch (error) {
-      console.error(`[BATCH MANAGER] Manual refresh failed for job ${jobId}:`, error);
+      logger.error(`[BATCH MANAGER] Manual refresh failed for job ${jobId}:`, error);
       
       // Handle 404 errors specifically
       if (error instanceof Error && error.message.includes('404')) {

--- a/src/hooks/useFallbackStorage.ts
+++ b/src/hooks/useFallbackStorage.ts
@@ -1,6 +1,7 @@
 
 import { useState, useRef } from 'react';
 import { useStorageCleanup } from './useStorageCleanup';
+import { logger } from '@/lib/logger';
 
 interface FallbackStorageHook {
   setItem: (key: string, value: string) => boolean;
@@ -26,11 +27,11 @@ export const useFallbackStorage = (): FallbackStorageHook => {
         return true;
       }
     } catch (error) {
-      console.warn(`[FALLBACK STORAGE] localStorage failed for ${key}:`, error);
+      logger.warn(`[FALLBACK STORAGE] localStorage failed for ${key}:`, error);
     }
 
     // Fallback to memory storage
-    console.log(`[FALLBACK STORAGE] Using memory storage for ${key}`);
+    logger.info(`[FALLBACK STORAGE] Using memory storage for ${key}`);
     memoryStorage.current[key] = value;
     setIsUsingFallback(true);
     setStorageStatus('memory');
@@ -45,7 +46,7 @@ export const useFallbackStorage = (): FallbackStorageHook => {
         return value;
       }
     } catch (error) {
-      console.warn(`[FALLBACK STORAGE] localStorage read failed for ${key}:`, error);
+      logger.warn(`[FALLBACK STORAGE] localStorage read failed for ${key}:`, error);
     }
 
     // Check memory storage
@@ -57,7 +58,7 @@ export const useFallbackStorage = (): FallbackStorageHook => {
     try {
       localStorage.removeItem(key);
     } catch (error) {
-      console.warn(`[FALLBACK STORAGE] localStorage remove failed for ${key}:`, error);
+      logger.warn(`[FALLBACK STORAGE] localStorage remove failed for ${key}:`, error);
     }
 
     delete memoryStorage.current[key];

--- a/src/hooks/useFileValidation.ts
+++ b/src/hooks/useFileValidation.ts
@@ -5,6 +5,7 @@ import { validateFile, validatePayeeData } from "@/lib/fileValidation";
 import { ValidationResult, PayeeRecord } from "@/lib/fileValidation/types";
 import { handleError, showErrorToast } from "@/lib/errorHandler";
 import { useToast } from "@/components/ui/use-toast";
+import { logger } from '@/lib/logger';
 
 export const useFileValidation = () => {
   const [file, setFile] = useState<File | null>(null);
@@ -92,7 +93,7 @@ export const useFileValidation = () => {
 
       setOriginalFileData(fullData);
 
-      console.log(`[FILE VALIDATION] Stored ${fullData.length} rows of original data with ${headers.length} columns`);
+      logger.info(`[FILE VALIDATION] Stored ${fullData.length} rows of original data with ${headers.length} columns`);
 
       const result: ValidationResult = {
         payees,
@@ -114,7 +115,7 @@ export const useFileValidation = () => {
       return { success: true, headers, fullData };
     } catch (error) {
       const appError = handleError(error, 'File Upload');
-      console.error("Error parsing file:", error);
+      logger.error("Error parsing file:", error);
       setFileError(appError.message);
       setValidationStatus('error');
       setFile(null);
@@ -144,7 +145,7 @@ export const useFileValidation = () => {
         return { raw_name: raw, norm_name: norm };
       });
 
-      console.log(`[FILE VALIDATION] Maintaining exact 1:1 correspondence: ${originalFileData.length} rows = ${payees.length} payees`);
+      logger.info(`[FILE VALIDATION] Maintaining exact 1:1 correspondence: ${originalFileData.length} rows = ${payees.length} payees`);
 
       const result: ValidationResult = {
         payees,

--- a/src/hooks/useRetry.ts
+++ b/src/hooks/useRetry.ts
@@ -1,6 +1,7 @@
 
 import { useState, useCallback } from 'react';
 import { AppError, handleError } from '@/lib/errorHandler';
+import { logger } from '@/lib/logger';
 
 interface RetryState {
   isRetrying: boolean;
@@ -52,7 +53,7 @@ export const useRetry = <T extends any[], R>(
           const appError = handleError(error, 'Retry operation');
           
           if (attemptNumber < maxRetries) {
-            console.log(`[RETRY] Attempt ${attemptNumber + 1} failed, retrying in ${baseDelay * Math.pow(2, attemptNumber)}ms`);
+            logger.warn(`[RETRY] Attempt ${attemptNumber + 1} failed, retrying in ${baseDelay * Math.pow(2, attemptNumber)}ms`);
             
             // Exponential backoff
             await new Promise(resolve => 

--- a/src/lib/backend/apiKeyService.ts
+++ b/src/lib/backend/apiKeyService.ts
@@ -1,4 +1,5 @@
 import { v4 as uuidv4 } from 'uuid';
+import { logger } from '@/lib/logger';
 
 const ENC_KEY_STORAGE = 'api_key_enc_key_permanent';
 
@@ -8,20 +9,20 @@ async function getCryptoKey(): Promise<CryptoKey> {
     try {
       const raw = Uint8Array.from(atob(stored), c => c.charCodeAt(0));
       const key = await crypto.subtle.importKey('raw', raw, 'AES-GCM', false, ['encrypt', 'decrypt']);
-      console.log('[API_KEY_SERVICE] Successfully imported existing crypto key from permanent storage');
+      logger.info('[API_KEY_SERVICE] Successfully imported existing crypto key from permanent storage');
       return key;
     } catch (error) {
-      console.error('[API_KEY_SERVICE] Failed to import stored crypto key, generating new one:', error);
+      logger.error('[API_KEY_SERVICE] Failed to import stored crypto key, generating new one:', error);
       localStorage.removeItem(ENC_KEY_STORAGE);
     }
   }
   
-  console.log('[API_KEY_SERVICE] Generating new crypto key for permanent storage...');
+  logger.info('[API_KEY_SERVICE] Generating new crypto key for permanent storage...');
   const key = await crypto.subtle.generateKey({ name: 'AES-GCM', length: 256 }, true, ['encrypt', 'decrypt']);
   const raw = await crypto.subtle.exportKey('raw', key);
   const encoded = btoa(String.fromCharCode(...new Uint8Array(raw)));
   localStorage.setItem(ENC_KEY_STORAGE, encoded);
-  console.log('[API_KEY_SERVICE] New crypto key generated and stored permanently');
+  logger.info('[API_KEY_SERVICE] New crypto key generated and stored permanently');
   return key;
 }
 
@@ -60,7 +61,7 @@ const STORAGE_PREFIX = 'secure_api_key_';
  */
 export async function storeApiKey(apiKey: string): Promise<string> {
   try {
-    console.log('[API_KEY_SERVICE] Storing new API key...');
+    logger.info('[API_KEY_SERVICE] Storing new API key...');
     const id = uuidv4();
     const token = uuidv4();
 
@@ -80,10 +81,10 @@ export async function storeApiKey(apiKey: string): Promise<string> {
     tokenMap[token] = id;
     localStorage.setItem(`${STORAGE_PREFIX}token_map`, JSON.stringify(tokenMap));
 
-    console.log('[API_KEY_SERVICE] API key stored successfully with token:', token.slice(-8));
+    logger.info('[API_KEY_SERVICE] API key stored successfully with token:', token.slice(-8));
     return token;
   } catch (error) {
-    console.error('[API_KEY_SERVICE] Failed to store API key:', error);
+    logger.error('[API_KEY_SERVICE] Failed to store API key:', error);
     throw new Error('Failed to securely store API key');
   }
 }
@@ -93,12 +94,12 @@ export async function storeApiKey(apiKey: string): Promise<string> {
  */
 export async function getApiKey(token: string): Promise<string | null> {
   try {
-    console.log('[API_KEY_SERVICE] Retrieving API key for token:', token.slice(-8));
+    logger.info('[API_KEY_SERVICE] Retrieving API key for token:', token.slice(-8));
     
     // Check if we have an encryption key first
     const hasEncryptionKey = !!localStorage.getItem(ENC_KEY_STORAGE);
     if (!hasEncryptionKey) {
-      console.warn('[API_KEY_SERVICE] No encryption key found in permanent storage');
+      logger.warn('[API_KEY_SERVICE] No encryption key found in permanent storage');
       // Try to regenerate the encryption key - this will fail for existing encrypted data
       // but we'll handle that gracefully
     }
@@ -108,14 +109,14 @@ export async function getApiKey(token: string): Promise<string | null> {
     const id = tokenMap[token];
     
     if (!id) {
-      console.warn('[API_KEY_SERVICE] Token not found in token map');
+      logger.warn('[API_KEY_SERVICE] Token not found in token map');
       return null;
     }
     
     // Get the stored key entry
     const storedEntry = localStorage.getItem(`${STORAGE_PREFIX}${id}`);
     if (!storedEntry) {
-      console.warn('[API_KEY_SERVICE] Stored API key entry not found for ID:', id);
+      logger.warn('[API_KEY_SERVICE] Stored API key entry not found for ID:', id);
       return null;
     }
     
@@ -123,7 +124,7 @@ export async function getApiKey(token: string): Promise<string | null> {
     
     // Verify the token matches
     if (entry.token !== token) {
-      console.warn('[API_KEY_SERVICE] Token mismatch in stored entry');
+      logger.warn('[API_KEY_SERVICE] Token mismatch in stored entry');
       return null;
     }
     
@@ -134,16 +135,16 @@ export async function getApiKey(token: string): Promise<string | null> {
     try {
       const { iv, data } = JSON.parse(entry.apiKey);
       const decryptedKey = await decryptValue(iv, data);
-      console.log('[API_KEY_SERVICE] API key retrieved and decrypted successfully');
+      logger.info('[API_KEY_SERVICE] API key retrieved and decrypted successfully');
       return decryptedKey;
     } catch (decryptError) {
-      console.error('[API_KEY_SERVICE] Failed to decrypt API key - encryption key may be missing:', decryptError);
+      logger.error('[API_KEY_SERVICE] Failed to decrypt API key - encryption key may be missing:', decryptError);
       // If decryption fails due to missing encryption key, delete the invalid entry
       deleteApiKey(token);
       return null;
     }
   } catch (error) {
-    console.error('[API_KEY_SERVICE] Failed to retrieve API key:', error);
+    logger.error('[API_KEY_SERVICE] Failed to retrieve API key:', error);
     return null;
   }
 }
@@ -155,10 +156,10 @@ export function hasSavedApiKey(): boolean {
   try {
     const tokenMap = JSON.parse(localStorage.getItem(`${STORAGE_PREFIX}token_map`) || '{}');
     const hasKeys = Object.keys(tokenMap).length > 0;
-    console.log('[API_KEY_SERVICE] Has saved API keys:', hasKeys);
+    logger.info('[API_KEY_SERVICE] Has saved API keys:', hasKeys);
     return hasKeys;
   } catch (error) {
-    console.error('[API_KEY_SERVICE] Error checking for saved API keys:', error);
+    logger.error('[API_KEY_SERVICE] Error checking for saved API keys:', error);
     return false;
   }
 }
@@ -168,12 +169,12 @@ export function hasSavedApiKey(): boolean {
  */
 export function deleteApiKey(token: string): boolean {
   try {
-    console.log('[API_KEY_SERVICE] Deleting API key for token:', token.slice(-8));
+    logger.info('[API_KEY_SERVICE] Deleting API key for token:', token.slice(-8));
     const tokenMap = JSON.parse(localStorage.getItem(`${STORAGE_PREFIX}token_map`) || '{}');
     const id = tokenMap[token];
     
     if (!id) {
-      console.warn('[API_KEY_SERVICE] Token not found for deletion');
+      logger.warn('[API_KEY_SERVICE] Token not found for deletion');
       return false;
     }
     
@@ -184,10 +185,10 @@ export function deleteApiKey(token: string): boolean {
     delete tokenMap[token];
     localStorage.setItem(`${STORAGE_PREFIX}token_map`, JSON.stringify(tokenMap));
     
-    console.log('[API_KEY_SERVICE] API key deleted successfully');
+    logger.info('[API_KEY_SERVICE] API key deleted successfully');
     return true;
   } catch (error) {
-    console.error('[API_KEY_SERVICE] Failed to delete API key:', error);
+    logger.error('[API_KEY_SERVICE] Failed to delete API key:', error);
     return false;
   }
 }
@@ -197,7 +198,7 @@ export function deleteApiKey(token: string): boolean {
  */
 export function clearAllApiKeys(): void {
   try {
-    console.log('[API_KEY_SERVICE] Clearing all stored API keys...');
+    logger.info('[API_KEY_SERVICE] Clearing all stored API keys...');
     const tokenMap = JSON.parse(localStorage.getItem(`${STORAGE_PREFIX}token_map`) || '{}');
     
     // Remove all stored key entries
@@ -211,9 +212,9 @@ export function clearAllApiKeys(): void {
     // Clear permanent encryption key
     localStorage.removeItem(ENC_KEY_STORAGE);
     
-    console.log('[API_KEY_SERVICE] All API keys cleared');
+    logger.info('[API_KEY_SERVICE] All API keys cleared');
   } catch (error) {
-    console.error('[API_KEY_SERVICE] Failed to clear API keys:', error);
+    logger.error('[API_KEY_SERVICE] Failed to clear API keys:', error);
   }
 }
 
@@ -247,7 +248,7 @@ export function getApiKeyDiagnostics(): {
       encryptionKeyStatus
     };
   } catch (error) {
-    console.error('[API_KEY_SERVICE] Error getting diagnostics:', error);
+    logger.error('[API_KEY_SERVICE] Error getting diagnostics:', error);
     return {
       hasTokenMap: false,
       tokenCount: 0,
@@ -274,7 +275,7 @@ export function getStoredApiKeyMetadata(): Array<{id: string, created: number, l
       };
     });
   } catch (error) {
-    console.error('Failed to get API key metadata:', error);
+    logger.error('Failed to get API key metadata:', error);
     return [];
   }
 }

--- a/src/lib/errorHandler.ts
+++ b/src/lib/errorHandler.ts
@@ -1,4 +1,5 @@
 import { toast } from "@/hooks/use-toast";
+import { logger } from '@/lib/logger';
 
 export interface AppError {
   code: string;
@@ -65,7 +66,7 @@ export const RETRY_INSTRUCTIONS: Record<string, string> = {
 };
 
 export const handleError = (error: unknown, context?: string): AppError => {
-  console.error(`[ERROR HANDLER] ${context || 'Unknown context'}:`, error);
+  logger.error(`[ERROR HANDLER] ${context || 'Unknown context'}:`, error);
 
   if (error instanceof BatchProcessingError || error instanceof FileValidationError) {
     return error;
@@ -177,7 +178,7 @@ export const showErrorToast = (error: AppError, context?: string) => {
   });
 
   // Log detailed error for debugging
-  console.error(`[${error.code}] ${error.message}`, error.details);
+  logger.error(`[${error.code}] ${error.message}`, error.details);
 };
 
 export const showRetryableErrorToast = (
@@ -196,7 +197,7 @@ export const showRetryableErrorToast = (
 
     // For now, we'll just show the error without the retry button
     // The user can manually retry through the UI
-    console.log('[RETRY] Retryable error occurred:', error);
+    logger.warn('[RETRY] Retryable error occurred:', error);
   } else {
     showErrorToast(error, context);
   }

--- a/src/lib/fileValidation/dataValidator.ts
+++ b/src/lib/fileValidation/dataValidator.ts
@@ -3,9 +3,10 @@ import { FileValidationError, ERROR_CODES } from '../errorHandler';
 import { FileValidationResult } from './types';
 import { MAX_ROWS } from './constants';
 import { cleanPayeeNames } from './payeeExtractor';
+import { logger } from '@/lib/logger';
 
 export const validatePayeeData = (data: any[], selectedColumn: string): FileValidationResult => {
-  console.log(`[PAYEE VALIDATION] Validating ${data.length} rows for column: ${selectedColumn}`);
+  logger.info(`[PAYEE VALIDATION] Validating ${data.length} rows for column: ${selectedColumn}`);
 
   if (!data || data.length === 0) {
     return {
@@ -64,7 +65,7 @@ export const validatePayeeData = (data: any[], selectedColumn: string): FileVali
   const uniquePayees = [...new Set(payeeNames)];
   const duplicateCount = payeeNames.length - uniquePayees.length;
 
-  console.log(`[PAYEE VALIDATION] Found ${payeeNames.length} total payees, ${uniquePayees.length} unique, ${duplicateCount} duplicates`);
+  logger.info(`[PAYEE VALIDATION] Found ${payeeNames.length} total payees, ${uniquePayees.length} unique, ${duplicateCount} duplicates`);
 
   return {
     isValid: true,

--- a/src/lib/fileValidation/fileValidator.ts
+++ b/src/lib/fileValidation/fileValidator.ts
@@ -2,9 +2,10 @@
 import { FileValidationError, ERROR_CODES } from '../errorHandler';
 import { FileValidationResult } from './types';
 import { MAX_FILE_SIZE, SUPPORTED_EXTENSIONS, VALID_MIME_TYPES } from './constants';
+import { logger } from '@/lib/logger';
 
 export const validateFile = (file: File): FileValidationResult => {
-  console.log(`[FILE VALIDATION] Validating file: ${file.name}, size: ${file.size} bytes`);
+  logger.info(`[FILE VALIDATION] Validating file: ${file.name}, size: ${file.size} bytes`);
 
   // Check file size
   if (file.size === 0) {
@@ -44,7 +45,7 @@ export const validateFile = (file: File): FileValidationResult => {
 
   // Check MIME type for additional validation
   if (file.type && !VALID_MIME_TYPES.includes(file.type)) {
-    console.warn(`[FILE VALIDATION] Unexpected MIME type: ${file.type}, but extension is valid`);
+    logger.warn(`[FILE VALIDATION] Unexpected MIME type: ${file.type}, but extension is valid`);
   }
 
   return {

--- a/src/lib/fileValidation/payeeExtractor.ts
+++ b/src/lib/fileValidation/payeeExtractor.ts
@@ -1,4 +1,5 @@
 import { ValidationResult } from './types';
+import { logger } from '@/lib/logger';
 
 export const validateFileContents = (data: any[]): ValidationResult => {
   if (!Array.isArray(data) || data.length === 0) {
@@ -51,7 +52,7 @@ export const validateFileContents = (data: any[]): ValidationResult => {
     payeeNames.push(payeeName || '[Empty]');
   }
 
-  console.log(`[FILE VALIDATION] Extracted ${payeeNames.length} payee names (including empty) and preserved ${originalData.length} original data rows with exact 1:1 correspondence`);
+  logger.info(`[FILE VALIDATION] Extracted ${payeeNames.length} payee names (including empty) and preserved ${originalData.length} original data rows with exact 1:1 correspondence`);
   
   return {
     payeeNames,

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -15,7 +15,6 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import ClassificationErrorBoundary from "@/components/ClassificationErrorBoundary";
 
 const Index = () => {
-  console.log('[INDEX] Index page rendering...');
   
   const [classificationResults, setClassificationResults] = useState<PayeeClassification[]>([]);
   const [lastProcessingSummary, setLastProcessingSummary] = useState<BatchProcessingResult | null>(null);

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,11 +1,12 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { logger } from '@/lib/logger';
 
 const NotFound = () => {
   const location = useLocation();
 
   useEffect(() => {
-    console.error(
+    logger.warn(
       "404 Error: User attempted to access non-existent route:",
       location.pathname
     );


### PR DESCRIPTION
## Summary
- replace console.* usage with centralized logger
- remove leftover debugging logs

## Testing
- `npm test` *(fails: AssertionError in tests/resultStorage.test.ts)*
- `npm run lint` *(fails: ESLint errors in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a7792110b08321bdfc2f48de271264