### PR TITLE
Account for memory storage in size calculations

### DIFF
--- a/src/lib/storage/resultStorage.ts
+++ b/src/lib/storage/resultStorage.ts
@@ -85,6 +85,7 @@ export const saveProcessingResults = async (
   const classificationBuffer = insertedRows.map((row, idx) => ({
     row_id: row.id as number,
     classification: results[idx].result,
+    prompt_version: promptVersion,
   }));
   await upsertClassifications(classificationBuffer);
 

--- a/src/services/storageService.ts
+++ b/src/services/storageService.ts
@@ -31,15 +31,26 @@ class UnifiedStorageService implements StorageService {
 
   getSize(): number {
     let total = 0;
-    try {
-      for (let key in localStorage) {
-        if (localStorage.hasOwnProperty(key)) {
-          total += localStorage[key].length + key.length;
+    const hasLocalStorage = typeof localStorage !== 'undefined';
+
+    if (hasLocalStorage) {
+      try {
+        for (const [key, value] of Object.entries(localStorage)) {
+          if (typeof value === 'string') {
+            total += key.length + value.length;
+          }
         }
+      } catch (error) {
+        logger.error('[STORAGE] Error calculating size:', error);
       }
-    } catch (error) {
-      logger.error('[STORAGE] Error calculating size:', error);
     }
+
+    if (this._isUsingFallback || !hasLocalStorage) {
+      for (const [key, value] of Object.entries(this.memoryStorage)) {
+        total += key.length + value.length;
+      }
+    }
+
     return total;
   }
 

--- a/tests/storageService.test.ts
+++ b/tests/storageService.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi } from 'vitest';
+import { storageService } from '@/services/storageService';
+
+function createLocalStorageMock() {
+  const store: Record<string, string> = {};
+  const localStorageMock: any = {
+    getItem(key: string) {
+      return key in store ? store[key] : null;
+    },
+    setItem(key: string, value: string) {
+      store[key] = value;
+      Object.defineProperty(localStorageMock, key, {
+        value,
+        writable: true,
+        configurable: true,
+        enumerable: true,
+      });
+    },
+    removeItem(key: string) {
+      delete store[key];
+      delete localStorageMock[key];
+    },
+    clear() {
+      for (const key of Object.keys(store)) {
+        delete store[key];
+        delete localStorageMock[key];
+      }
+    },
+  };
+  Object.defineProperties(localStorageMock, {
+    getItem: { enumerable: false },
+    setItem: { enumerable: false },
+    removeItem: { enumerable: false },
+    clear: { enumerable: false },
+  });
+  return localStorageMock as Storage;
+}
+
+describe('storageService.getSize', () => {
+  it('calculates size based on localStorage entries', () => {
+    const mock = createLocalStorageMock();
+    vi.stubGlobal('localStorage', mock);
+
+    (storageService as any).memoryStorage = {};
+    (storageService as any)._isUsingFallback = false;
+
+    mock.setItem('foo', 'bar');
+    mock.setItem('baz', 'qux');
+
+    const expected = 'foo'.length + 'bar'.length + 'baz'.length + 'qux'.length;
+    expect(storageService.getSize()).toBe(expected);
+  });
+
+  it('sums memory storage when localStorage is unavailable', () => {
+    vi.stubGlobal('localStorage', undefined);
+
+    (storageService as any).memoryStorage = { foo: 'bar', baz: 'qux' };
+    (storageService as any)._isUsingFallback = true;
+
+    const expected = 'foo'.length + 'bar'.length + 'baz'.length + 'qux'.length;
+    expect(storageService.getSize()).toBe(expected);
+  });
+});
+


### PR DESCRIPTION
## Summary
- handle memory fallback entries in `getSize` and avoid `for…in`
- include `prompt_version` when buffering classifications
- add tests for storage size in local and fallback scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a779248488832190c532605e4d5a61