### PR TITLE
Use Link component for NotFound navigation

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { useLocation, Link } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- use `Link` from `react-router-dom` in NotFound page
- replace anchor tag with `<Link>` to enable client-side navigation

## Testing
- `npm run lint` *(fails: 127 errors, 12 warnings)*
- `npm test` *(fails: 1 failed, 37 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a77923b87c832189d83fdbf82ca21d